### PR TITLE
GNU Make pipeline runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Schema output
+output/

--- a/Makefile
+++ b/Makefile
@@ -12,27 +12,34 @@ RUN := poetry run
 
 ### Help ###
 .PHONY: help
-help:
-	@echo "╭───────────────────────────────────────────────────────────╮"
-	@echo "│ Makefile for dm-bip                                       │"
-	@echo "│ ────────────────────────                                  │"
-	@echo "│ Usage:                                                    │"
-	@echo "│     make <target>                                         │"
-	@echo "│                                                           │"
-	@echo "│ Targets:                                                  │"
-	@echo "│     help                Print this help message           │"
-	@echo "│     all                 Install everything                │"
-	@echo "│     fresh               Clean and install everything      │"
-	@echo "│     clean               Clean up build artifacts          │"
-	@echo "│     clobber             Clean up generated files          │"
-	@echo "│                                                           │"
-	@echo "│     install             Set up the virtual environment    |"
-	@echo "│     docs                Generate documentation            │"
-	@echo "│     test                Run tests                         │"
-	@echo "│     lint                Lint all code                     │"
-	@echo "│     format              Format all code                   │"
-	@echo "│     coverage            Measure and report test coverage  │"
-	@echo "╰───────────────────────────────────────────────────────────╯"
+help::
+	@echo "╭─────────────────────────────────────────────────────────────╮"
+	@echo "│ Makefile for dm-bip                                         │"
+	@echo "│ ────────────────────────                                    │"
+	@echo "│ Usage:                                                      │"
+	@echo "│     make <target>                                           │"
+	@echo "│                                                             │"
+	@echo "│ Schema targets:                                             │"
+	@echo "│     create-schema       Create a schema from a set of files │"
+	@echo "│     lint-schema         Lint a schema from a set of files   │"
+	@echo "│     clean-schema        Remove all generated schema files   │"
+	@echo "│     debug-schema        Print all schema variables          │"
+	@echo "│                                                             │"
+	@echo "│ Project targets:                                            │"
+	@echo "│     help                Print this help message             │"
+	@echo "│     all                 Install everything                  │"
+	@echo "│     fresh               Clean and install everything        │"
+	@echo "│     clean               Clean up build artifacts            │"
+	@echo "│     clobber             Clean up generated files            │"
+	@echo "│                                                             │"
+	@echo "│     install             Set up the virtual environment      |"
+	@echo "│     docs                Generate documentation              │"
+	@echo "│     test                Run tests                           │"
+	@echo "│     lint                Lint all code                       │"
+	@echo "│     format              Format all code                     │"
+	@echo "│     coverage            Measure and report test coverage    │"
+	@echo "╰─────────────────────────────────────────────────────────────╯"
+	@echo
 
 
 ### Installation and Setup ###
@@ -100,3 +107,5 @@ format: $(PYTHON)
 coverage: $(PYTHON)
 	$(RUN) coverage run -m pytest tests
 	$(RUN) coverage report -m
+
+include pipeline.Makefile

--- a/pipeline.Makefile
+++ b/pipeline.Makefile
@@ -1,0 +1,37 @@
+RUN := poetry run
+
+INPUT_DIR ?= input
+OUTPUT_DIR ?= output
+INPUT_FILES ?= $(shell find $(INPUT_DIR) -type f -regex '.*\.[ct]sv')
+INPUT_FILENAMES := $(INPUT_FILES:$(INPUT_DIR)/%=%)
+
+step_files = $(foreach filename,$(INPUT_FILENAMES),$(OUTPUT_DIR)/$(1)/$(filename))
+
+STEP_0_NAME := 00-original
+STEP_0_FILES := $(call step_files,$(STEP_0_NAME))
+
+STEP_1_NAME := 01-cleaned
+STEP_1_FILES := $(call step_files,$(STEP_1_NAME))
+
+STEP_2_NAME := 02-schema-inferred
+STEP_2_FILES := $(call step_files,$(STEP_2_NAME))
+
+z:
+	@echo input: $(INPUT_FILES)
+	@echo
+	@echo input names: $(INPUT_FILENAMES)
+	@echo
+	@echo step 0: $(STEP_0_FILES)
+	@echo
+	@echo step 1: $(STEP_1_FILES)
+	@echo
+	@echo step 2: $(STEP_2_FILES)
+
+$(OUTPUT_DIR)/00-original/%: $(INPUT_DIR)/%
+	cp $< $@
+
+$(OUTPUT_DIR)/01-cleaned/%: $(OUTPUT_DIR)/0-original/%
+	$(RUN) src/dm_bip/clean_data.py $< > $@
+
+$(OUTPUT_DIR)/02-schema-inferred/%: $(OUTPUT_DIR)/1-cleaned/%
+	$(RUN) schemauto generalize-csv $< -o $@


### PR DESCRIPTION
This adds makefile targets to create and validate schemas based on configurable input files. I've added some documentation in `make help` to show usage.

There are four environment variables which are read by `make`. Here they are with their default values:

```
  DM_SCHEMA_NAME=Schema
  DM_INPUT_DIR=input
  DM_INPUT_FILES=
  DM_OUTPUT_DIR=output/Schema
```

When those variables are set appropriately, a schema can be generated with `make create-schema` and linted with `make lint-schema`.