### PR TITLE
Add Replacer data cleaner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ lint.extend-ignore = [
     "D211",  # `no-blank-line-before-class`
     "D212",  # `multi-line-summary-first-line`
     "D203",  # `blank-line-before-docstring`
-    ]
+    "S101",  # `assert`
+]
 line-length = 120
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/simple_clean/replace_values.py
+++ b/simple_clean/replace_values.py
@@ -1,0 +1,80 @@
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar, cast
+
+T = TypeVar("T", bound=dict)
+LookupTable = dict[str, dict[str, dict[str, str]]]
+
+
+@dataclass
+class Replacement:
+    """A value that should be replaced for a value in a column."""
+
+    filename: str
+    column_name: str
+    original_value: str
+    replacement_value: str
+
+
+def get_or_create_dict(key: str, obj: dict[str, T]) -> T:
+    """Retrieve a dict from a dict at a string, or to create it if it does not exist."""
+    if key in obj:
+        return obj[key]
+    val: T = cast(T, {})
+    obj[key] = val
+    return val
+
+
+class Replacer:
+    """
+    A class that replace values from a lookup table.
+
+    :param table: The lookup table where replacement values will be found.
+    """
+
+    def __init__(self, table: LookupTable):
+        self.table = table
+
+    @classmethod
+    def from_file(cls, replacements_file: Path):
+        """
+        Create a replacer from a CSV table.
+
+        :param replacements_file: A path to a CSV file with the following columns:
+            * filename
+            * column_name
+            * original_value
+            * replacement_value
+        """
+        lookup_table: LookupTable = {}
+
+        with open(replacements_file, "r") as fp:
+            reader = csv.DictReader(fp)
+            replacements = [Replacement(**row) for row in reader]
+
+        for replacement in replacements:
+            column_lookup = get_or_create_dict(replacement.filename, lookup_table)
+            value_lookup = get_or_create_dict(replacement.column_name, column_lookup)
+            value_lookup[replacement.original_value] = replacement.replacement_value
+
+        return cls(lookup_table)
+
+    def lookup(self, filename: str, column_name: str, value: str):
+        """Look up a value in a replacement table."""
+        column_lookup = self.table.get(filename, None)
+        if column_lookup is None:
+            return value
+
+        value_lookup = column_lookup.get(column_name, None)
+        if value_lookup is None:
+            return value
+
+        return value_lookup.get(value, value)
+
+    def iter_dictreader(self, filename: str, reader: csv.DictReader[str]):
+        """Wrap a csv.DictReader to replace values as it reads."""
+        for row in reader:
+            for k, v in row.items():
+                row[k] = self.lookup(filename, k, v)
+            yield row

--- a/simple_clean/replace_values.py
+++ b/simple_clean/replace_values.py
@@ -31,6 +31,13 @@ def get_or_create_dict(key: str, obj: dict[str, T]) -> T:
     return val
 
 
+def detect_dialect(csv_fp: TextIO):
+    """Detect the dialect of a CSV stream, accepting comma or tab delimeters."""
+    dialect = csv.Sniffer().sniff(csv_fp.read(1024), delimiters=",\t")
+    csv_fp.seek(0)
+    return dialect
+
+
 class Replacer:
     """
     A class that replace values from a lookup table.
@@ -56,7 +63,8 @@ class Replacer:
         lookup_table: LookupTable = {}
 
         with open(replacements_file, "r") as fp:
-            reader = csv.DictReader(fp)
+            dialect = detect_dialect(fp)
+            reader = csv.DictReader(fp, dialect=dialect)
             replacements = [Replacement(**row) for row in reader]
 
         for replacement in replacements:
@@ -86,7 +94,7 @@ class Replacer:
         :param output_fp: A text stream to which to write the resulting CSV.
         """
         with csv_file.open("r") as in_fp:
-            dialect = csv.Sniffer().sniff(in_fp.read(2048), delimiters=",\t")
+            dialect = detect_dialect(in_fp)
             in_fp.seek(0)
             reader = csv.DictReader(in_fp, dialect=dialect)
 

--- a/tests/test_replace_values.py
+++ b/tests/test_replace_values.py
@@ -1,3 +1,5 @@
+"""Tests for the Replacer data cleaner."""
+
 import csv
 from dataclasses import astuple
 from io import StringIO
@@ -8,6 +10,7 @@ from simple_clean.replace_values import Replacement, Replacer
 
 
 def create_replacer(replacements: list[Replacement]):
+    """Create a replacer class with some replacements without loading a file."""
     file = NamedTemporaryFile("w")
     file.write("filename,column_name,original_value,replacement_value\n")
     for replacement in replacements:
@@ -18,6 +21,7 @@ def create_replacer(replacements: list[Replacement]):
 
 
 def test_replacement_lookup():
+    """Ensure replacer replaces marked values, and leaves unmarked values alone."""
     replacements: list[Replacement] = [
         Replacement("a.txt", "name", "BADNAME", "goodname"),
         Replacement("a.txt", "name", "BADNAME2", "goodname2"),
@@ -38,6 +42,7 @@ def test_replacement_lookup():
 
 
 def test_replace_csv():
+    """Ensure replacing data in a file works."""
     csv_file = NamedTemporaryFile("wt", newline="")
     writer = csv.DictWriter(csv_file, ["id", "name", "label"], delimiter="\t")
 

--- a/tests/test_replace_values.py
+++ b/tests/test_replace_values.py
@@ -1,0 +1,35 @@
+from dataclasses import astuple
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from simple_clean.replace_values import Replacement, Replacer
+
+
+def create_replacer(replacements: list[Replacement]):
+    file = NamedTemporaryFile("w")
+    file.write("filename,column_name,original_value,replacement_value\n")
+    for replacement in replacements:
+        file.write(",".join(astuple(replacement)) + "\n")
+    file.seek(0)
+    replacer = Replacer.from_file(Path(file.name))
+    return replacer
+
+
+def test_replacement_lookup():
+    replacements: list[Replacement] = [
+        Replacement("a.txt", "name", "BADNAME", "goodname"),
+        Replacement("a.txt", "name", "BADNAME2", "goodname2"),
+        Replacement("b.txt", "label", "BADLABEL", "goodlabel"),
+    ]
+    replacer = create_replacer(replacements)
+
+    assert replacer.table == {
+        "a.txt": {"name": {"BADNAME": "goodname", "BADNAME2": "goodname2"}},
+        "b.txt": {"label": {"BADLABEL": "goodlabel"}},
+    }
+
+    assert replacer.lookup("a.txt", "name", "BADNAME") == "goodname"
+    assert replacer.lookup("a.txt", "name", "BADNAME2") == "goodname2"
+    assert replacer.lookup("a.txt", "a", "b") == "b"
+    assert replacer.lookup("b.txt", "label", "BADLABEL") == "goodlabel"
+    assert replacer.lookup("c.txt", "a", "b") == "b"


### PR DESCRIPTION
Adds a new data cleaner to replace values in a series of CSV/TSV files.

The values to replace are defined in their own CSV or TSV. The format of that file is described in the CLI.