### PR TITLE
Add Python 3.11

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # python-version: ["3.12", "3.13" ]
-        python-version: ["3.12" ] # Removing 3.13 for now due to dependency issues
+        python-version: ["3.11", "3.12" ] # Removing 3.13 for now due to dependency issues
 
     steps:
       - uses: actions/checkout@v3.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 click = "*"
 importlib-metadata = ">=8.2.0"
 pandas = "^2.2.3"


### PR DESCRIPTION
Adding python 3.11 for BDC Data Studio. It's a little sad they don't have a default support for 3.12 but I may need to use 3.11 for the time being.