### PR TITLE
Script to pivot conditions as col headers to rows

### DIFF
--- a/pipeline.Makefile
+++ b/pipeline.Makefile
@@ -109,6 +109,14 @@ schema-lint: $(SCHEMA_FILE)
 		fi;
 	@echo "Schema linting log written to $(SCHEMA_LINT_LOG)"
 
+
+COND_START_COL ?= 6
+
+.PHONY: extract-conditions
+extract-conditions:
+	./src/dm_bip/cleaners/extract_conditions.sh $(input_file) $(COND_START_COL)
+
+
 .PHONY: annotate
 annotate:
 	@echo "** Annotate data file with ontology terms using config and input_file: $(input_file)"

--- a/src/dm_bip/cleaners/extract_conditions.sh
+++ b/src/dm_bip/cleaners/extract_conditions.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Usage: ./extract_conditions.sh path/to/input.tsv 3
+
+input_file="$1"
+start_col="$2"
+
+# Get the directory and base name of the input file
+input_dir=$(dirname "$input_file")
+base_name=$(basename "$input_file" .tsv)
+
+# Construct the full output path in the same directory
+output_file="${input_dir}/${base_name}-conditions.tsv"
+
+# Add column header and extract headers from the specified starting column to the end
+{
+  echo -e "conditions"
+  head -n 1 "$input_file" | awk -v start="$start_col" -F'\t' '{
+    for (i = start; i <= NF; i++) print $i
+  }'
+} > "$output_file"
+
+echo "Wrote condition headers to: $output_file"

--- a/toy_data/raw_data_conditions/README.md
+++ b/toy_data/raw_data_conditions/README.md
@@ -3,9 +3,12 @@
 The data files in this directory represent examples of conditions, e.g. diseases, phenotypes, or medical actions, that describe the health status of the participants in a study. The conditions data has historically been provided as either a few words to describe the condition, e.g. cardiomegaly, or as questions and answers as responses to survey questions, e.g. What is the status and age at diagnosis for each of these heart conditions? (Select all that apply.)  - Elevated cholesterol levels - Age at diagnosis 21 - 30 years.
 
 
-### File description
+### File descriptions
 1. `conditions_simple.tsv` - simple short description of the condition
     - `condition_source_text` - this column contains the extracted text of interest to annotate 
-2. `conditions_complex-questions.tsv` - questions and answers to survey questions 
+1. `conditions_complex-questions.tsv` - questions and answers to survey questions 
     - `condition_source_text` - this column contains the question and answer and relevant terms in this value should be annotated
     - `source_column` - this column contains the extracted text of interest to annotate as an example
+1. `conditions_headers.tsv` - example where the conditions are found in the column headers. These can be pivoted to row values using the `extract-conditions` make goal. The output file of `extract-conditions` is saved in the same directory as the input file named as: `{INPUT_FILE}-conditions.tsv`
+Example usage:  
+`make extract-conditions input_file=toy_data/raw_data_conditions/conditions_headers.tsv COND_START_COL=9`

--- a/toy_data/raw_data_conditions/conditions_headers.tsv
+++ b/toy_data/raw_data_conditions/conditions_headers.tsv
@@ -1,0 +1,2 @@
+MASKED_ID	AGE	SEX	RACE	ETHNICITY	BMI	HEIGHT	WEIGHT	Abnormalities of gait and mobility	Achalasia	Acute bronchitis	Acute kidney failure	acute myocardial infarction	Acute nasopharyngitis	Acute sinusitis
+123	8	Female	N/A	N/A	9	9	9	1	1	1	0	0   1	1	1


### PR DESCRIPTION
related to #91 

This PR adds a script and new make target to pivot condition text to annotate found in column headers to rows in a new file. An example toy data file with conditions as column headers is also included and the conditions toy data README is updated.