### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
+typing_extensions = "^4.0"
 click = "*"
 importlib-metadata = ">=8.2.0"
 pandas = "^2.2.3"


### PR DESCRIPTION
Add typing_extensions dependency. For INCLUDE, folks ran into the error `ModuleNotFoundError: No module named 'typing_extensions'` during the project set-up after running `poetry run tox`. I have not tested this fix, but gather this is what is needed.