### PR TITLE
Add ai-harmonize CLI verb-group for RTI harmonization API

### DIFF
--- a/pipeline.Makefile
+++ b/pipeline.Makefile
@@ -200,6 +200,9 @@ Examples
 2. Run the pipeline for two files: `StudyA/data.tsv` and `StudyB/data.tsv`, with the default schema name:
 
     make pipeline DM_INPUT_FILES="StudyA/data.tsv StudyB/data.tsv"
+
+For individual operations (variable harmonization, trans-spec generation, metadata prep),
+see `dm-bip --help`.
 endef
 
 .PHONY: help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "schema-automator==0.5.5",
     "linkml-map==0.5.2",
     "typing-extensions>=4.0,<5",
+    "httpx>=0.27,<1",
 ]
 
 [project.scripts]
@@ -27,6 +28,7 @@ dev = [
     "docstr-coverage>=2.3.2",
     "ipykernel>=6.29.5,<7",
     "notebook>=7.4.2,<8",
+    "pytest-httpx>=0.30,<1",
 ]
 docs = [
     "mkdocs>=1.6",

--- a/src/dm_bip/ai_harmonize/__init__.py
+++ b/src/dm_bip/ai_harmonize/__init__.py
@@ -1,0 +1,1 @@
+"""Thin wrapper around RTI's hosted variable-harmonization API."""

--- a/src/dm_bip/ai_harmonize/cli.py
+++ b/src/dm_bip/ai_harmonize/cli.py
@@ -1,0 +1,233 @@
+"""Typer subapp for the AI harmonize verb-group: set-token, submit, status, fetch, wait, list."""
+
+from __future__ import annotations
+
+import enum
+import json as json_module
+import logging
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from dm_bip.ai_harmonize import storage
+from dm_bip.ai_harmonize.client import Client, HarmonizeError, content_type_for, decode_jwt_expiry
+from dm_bip.ai_harmonize.config import load_config
+
+logger = logging.getLogger("dm_bip.ai_harmonize")
+
+POLL_INTERVAL_SECONDS = 10
+TERMINAL_STATUSES = frozenset({"completed", "failed"})
+
+
+class LogLevel(str, enum.Enum):
+    """Verbosity controls for the ai-harmonize subapp."""
+
+    debug = "debug"
+    info = "info"
+    warning = "warning"
+    error = "error"
+    silent = "silent"
+
+
+_LOG_LEVEL_MAP = {
+    LogLevel.debug: logging.DEBUG,
+    LogLevel.info: logging.INFO,
+    LogLevel.warning: logging.WARNING,
+    LogLevel.error: logging.ERROR,
+    LogLevel.silent: logging.CRITICAL + 10,
+}
+
+
+app = typer.Typer(help="AI-assisted variable harmonization (RTI hosted API).")
+
+
+@app.callback()
+def _configure(
+    log_level: Annotated[
+        LogLevel,
+        typer.Option("--log-level", help="Set verbosity for this command."),
+    ] = LogLevel.info,
+) -> None:
+    """Configure logging for the ai-harmonize subapp."""
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    logger.handlers = [handler]
+    logger.setLevel(_LOG_LEVEL_MAP[log_level])
+    logger.propagate = False
+
+
+def _handle_api_error(exc: HarmonizeError) -> None:
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=1) from exc
+
+
+@app.command(name="set-token")
+def set_token(
+    token: Annotated[str, typer.Argument(help="JWT id-token obtained from Cognito.")],
+) -> None:
+    """Cache a JWT id-token for subsequent API calls; expiry comes from the JWT's `exp` claim."""
+    config = load_config()
+    expires_at = decode_jwt_expiry(token)
+    storage.save_token(
+        config.token_cache_path,
+        storage.CachedToken(token=token, expires_at=expires_at),
+    )
+    if expires_at is None:
+        typer.echo(
+            f"Token cached at {config.token_cache_path}.\n"
+            "Note: this doesn't look like a JWT; expiry could not be determined."
+        )
+    else:
+        when = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime(expires_at))
+        typer.echo(f"Token cached at {config.token_cache_path}; expires {when}.")
+
+
+@app.command()
+def submit(
+    input_file: Annotated[Path, typer.Argument(help="CSV/TSV/Excel file containing variable descriptions.")],
+    colname: Annotated[str, typer.Option("--col", "-c", help="Column name holding the descriptions to harmonize.")],
+    subset: Annotated[str, typer.Option("--subset", help="Python slice for sampling rows (e.g. '::1000').")] = "",
+    pool: Annotated[int, typer.Option("--pool", help="MongoDB vector search pool size.")] = 10,
+    chunk_size: Annotated[int, typer.Option("--chunk-size", help="Embedding batch size.")] = 10,
+    lim: Annotated[Optional[int], typer.Option("--lim", help="Number of top matches to return per variable.")] = None,
+) -> None:
+    """Submit a file for harmonization; prints the assigned job_id."""
+    if not input_file.exists():
+        typer.echo(f"Input file not found: {input_file}", err=True)
+        raise typer.Exit(code=2)
+
+    client = Client(load_config())
+    try:
+        response = client.request_upload_url(
+            filename=input_file.name,
+            colname=colname,
+            subset=subset,
+            pool=pool,
+            chunk_size=chunk_size,
+            lim=lim,
+        )
+        client.upload_file(response["upload_url"], input_file, content_type_for(input_file.name))
+    except HarmonizeError as exc:
+        _handle_api_error(exc)
+
+    manifest = storage.JobManifest(
+        job_id=response["job_id"],
+        submitted_at=time.time(),
+        parameters={
+            "filename": input_file.name,
+            "colname": colname,
+            "subset": subset,
+            "pool": pool,
+            "chunk_size": chunk_size,
+            "lim": lim,
+        },
+        s3_input_key=response.get("s3_key"),
+    )
+    storage.save_manifest(client.config.job_manifest_dir, manifest)
+    typer.echo(response["job_id"])
+
+
+@app.command()
+def status(
+    job_id: Annotated[str, typer.Argument(help="Job ID returned by `submit`.")],
+    as_json: Annotated[bool, typer.Option("--json", help="Emit the raw API response as JSON.")] = False,
+) -> None:
+    """Print the current status of a submitted job."""
+    client = Client(load_config())
+    try:
+        payload = client.get_status(job_id)
+    except HarmonizeError as exc:
+        _handle_api_error(exc)
+
+    if as_json:
+        typer.echo(json_module.dumps(payload, indent=2))
+    else:
+        typer.echo(payload.get("status", "unknown"))
+
+    manifest = storage.load_manifest(client.config.job_manifest_dir, job_id)
+    if manifest is not None:
+        manifest.last_status = payload.get("status")
+        manifest.s3_output_path = payload.get("s3_output_path") or manifest.s3_output_path
+        storage.save_manifest(client.config.job_manifest_dir, manifest)
+
+
+@app.command()
+def fetch(
+    job_id: Annotated[str, typer.Argument(help="Job ID of a completed job.")],
+    output: Annotated[Path, typer.Option("--output", "-o", help="Where to write the results CSV.")],
+) -> None:
+    """Download results for a completed job."""
+    client = Client(load_config())
+    try:
+        payload = client.get_status(job_id, include_download_url=True)
+    except HarmonizeError as exc:
+        _handle_api_error(exc)
+
+    if payload.get("status") != "completed":
+        typer.echo(f"Job {job_id} is not complete (status: {payload.get('status')}).", err=True)
+        raise typer.Exit(code=1)
+    url = payload.get("download_url")
+    if not url:
+        typer.echo("API did not return a download URL.", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        client.download_results(url, output)
+    except HarmonizeError as exc:
+        _handle_api_error(exc)
+    typer.echo(str(output))
+
+
+@app.command()
+def wait(
+    job_id: Annotated[str, typer.Argument(help="Job ID to wait on.")],
+    output: Annotated[
+        Optional[Path], typer.Option("--output", "-o", help="Also fetch results to this path when complete.")
+    ] = None,
+    interval: Annotated[int, typer.Option("--interval", help="Poll interval in seconds.")] = POLL_INTERVAL_SECONDS,
+) -> None:
+    """Poll until a job reaches a terminal status; optionally fetch results."""
+    client = Client(load_config())
+    while True:
+        try:
+            payload = client.get_status(job_id)
+        except HarmonizeError as exc:
+            _handle_api_error(exc)
+        current = payload.get("status", "unknown")
+        logger.info("job %s: %s", job_id, current)
+        if current in TERMINAL_STATUSES:
+            break
+        time.sleep(interval)
+
+    if current == "failed":
+        typer.echo(f"Job {job_id} failed: {payload.get('error_message', '(no message)')}", err=True)
+        raise typer.Exit(code=1)
+
+    if output is not None:
+        fetch(job_id=job_id, output=output)
+    else:
+        typer.echo("completed")
+
+
+@app.command(name="list")
+def list_jobs(
+    as_json: Annotated[bool, typer.Option("--json", help="Emit the manifest list as JSON.")] = False,
+) -> None:
+    """List locally-tracked harmonization jobs (newest first)."""
+    config = load_config()
+    manifests = storage.list_manifests(config.job_manifest_dir)
+    if as_json:
+        typer.echo(json_module.dumps([asdict(m) for m in manifests], indent=2, sort_keys=True))
+        return
+
+    if not manifests:
+        typer.echo("(no tracked jobs)")
+        return
+    for m in manifests:
+        ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(m.submitted_at))
+        status_str = m.last_status or "?"
+        typer.echo(f"{m.job_id}  {ts}  {status_str:<10}  {m.parameters.get('filename', '')}")

--- a/src/dm_bip/ai_harmonize/cli.py
+++ b/src/dm_bip/ai_harmonize/cli.py
@@ -188,7 +188,9 @@ def wait(
     output: Annotated[
         Optional[Path], typer.Option("--output", "-o", help="Also fetch results to this path when complete.")
     ] = None,
-    interval: Annotated[int, typer.Option("--interval", help="Poll interval in seconds.")] = POLL_INTERVAL_SECONDS,
+    interval: Annotated[
+        int, typer.Option("--interval", min=0, help="Poll interval in seconds.")
+    ] = POLL_INTERVAL_SECONDS,
 ) -> None:
     """Poll until a job reaches a terminal status; optionally fetch results."""
     client = Client(load_config())

--- a/src/dm_bip/ai_harmonize/client.py
+++ b/src/dm_bip/ai_harmonize/client.py
@@ -1,0 +1,190 @@
+"""HTTP client for RTI's hosted variable-harmonization API: token-based, with retry on transient errors."""
+
+from __future__ import annotations
+
+import base64
+import json as _json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from dm_bip.ai_harmonize import storage
+from dm_bip.ai_harmonize.config import Config
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+UPLOAD_TIMEOUT_SECONDS = 600.0
+RETRY_MAX_ATTEMPTS = 3
+RETRY_BACKOFF_BASE_SECONDS = 1.0
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+TOKEN_REFRESH_HINT = "Token expired or invalid. Refresh with `dm-bip ai-harmonize set-token <new-token>`."  # noqa: S105
+
+
+class HarmonizeError(Exception):
+    """Raised when the harmonization API returns an unrecoverable error."""
+
+
+class TokenMissingError(HarmonizeError):
+    """Raised when no token is configured (no env var, no cache file)."""
+
+
+_CONTENT_TYPES = {
+    ".csv": "text/csv",
+    ".tsv": "text/tab-separated-values",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+}
+
+
+def content_type_for(filename: str) -> str:
+    """Pick the S3 Content-Type for a given filename based on extension; defaults to octet-stream."""
+    return _CONTENT_TYPES.get(Path(filename).suffix.lower(), "application/octet-stream")
+
+
+def decode_jwt_expiry(token: str) -> float | None:
+    """Extract the `exp` claim from a JWT; returns None if the token isn't a decodable JWT."""
+    try:
+        _header, payload_b64, _sig = token.split(".")
+    except ValueError:
+        return None
+    padded = payload_b64 + "=" * (-len(payload_b64) % 4)
+    try:
+        payload = _json.loads(base64.urlsafe_b64decode(padded))
+        return float(payload["exp"])
+    except (ValueError, KeyError, _json.JSONDecodeError):
+        return None
+
+
+def _request_with_retry(
+    http: httpx.Client,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    json: Any = None,
+    timeout: float | None = None,
+) -> httpx.Response:
+    """Issue an HTTP request, retrying on 429/5xx with exponential backoff."""
+    last_exc: Exception | None = None
+    for attempt in range(1, RETRY_MAX_ATTEMPTS + 1):
+        try:
+            response = http.request(method, url, headers=headers, json=json, timeout=timeout)
+        except httpx.TransportError as exc:
+            last_exc = exc
+            logger.debug("Transport error on attempt %d/%d: %s", attempt, RETRY_MAX_ATTEMPTS, exc)
+        else:
+            if response.status_code not in RETRYABLE_STATUS_CODES:
+                return response
+            logger.debug(
+                "Retryable status %d on attempt %d/%d for %s %s",
+                response.status_code,
+                attempt,
+                RETRY_MAX_ATTEMPTS,
+                method,
+                url,
+            )
+            last_exc = HarmonizeError(f"HTTP {response.status_code}: {response.text[:200]}")
+
+        if attempt < RETRY_MAX_ATTEMPTS:
+            time.sleep(RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)))
+
+    raise HarmonizeError(f"Request failed after {RETRY_MAX_ATTEMPTS} attempts: {last_exc}")
+
+
+class Client:
+    """Session against the harmonization API; reads token from env var or cache file."""
+
+    def __init__(self, config: Config, http: httpx.Client | None = None) -> None:
+        """Create a client; pass an httpx.Client to override the default (useful for tests)."""
+        self.config = config
+        self.http = http or httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS)
+
+    def get_token(self) -> str:
+        """Return the JWT id-token from env or cache; raises TokenMissingError if neither has one."""
+        env_token = os.environ.get("AI_HARMONIZE_TOKEN", "").strip()
+        if env_token:
+            return env_token
+        cached = storage.load_token(self.config.token_cache_path)
+        if cached:
+            return cached.token
+        raise TokenMissingError(
+            "No token configured. Set one with `dm-bip ai-harmonize set-token <jwt>` "
+            "or via the AI_HARMONIZE_TOKEN env var."
+        )
+
+    def _api_call(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Hit an API endpoint with auth + retry; raise on 401 / non-2xx; return parsed JSON."""
+        url = f"{self.config.api_url}/{path.lstrip('/')}"
+        headers = {"Authorization": self.get_token()}
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+        response = _request_with_retry(self.http, method, url, headers=headers, json=json_body, timeout=timeout)
+        if response.status_code == 401:
+            raise HarmonizeError(TOKEN_REFRESH_HINT)
+        if not 200 <= response.status_code < 300:
+            raise HarmonizeError(f"{path} failed ({response.status_code}): {response.text[:300]}")
+        return response.json()
+
+    def request_upload_url(
+        self,
+        *,
+        filename: str,
+        colname: str,
+        subset: str = "",
+        pool: int = 10,
+        chunk_size: int = 10,
+        lim: int | None = None,
+    ) -> dict[str, Any]:
+        """Request a presigned S3 upload URL via /submit-file; returns dict with job_id, upload_url, s3_key."""
+        body: dict[str, Any] = {
+            "action": "get_upload_url",
+            "filename": filename,
+            "colname": colname,
+            "subset": subset,
+            "pool": pool,
+            "chunk_size": chunk_size,
+        }
+        if lim is not None:
+            body["lim"] = lim
+        return self._api_call("POST", "submit-file", json_body=body)
+
+    def upload_file(self, upload_url: str, path: Path, content_type: str) -> None:
+        """PUT a file to a presigned S3 URL — no auth header (URL is pre-signed)."""
+        logger.info("Uploading %s (%d bytes) to S3", path.name, path.stat().st_size)
+        with path.open("rb") as fh:
+            response = self.http.put(
+                upload_url,
+                content=fh.read(),
+                headers={"Content-Type": content_type},
+                timeout=UPLOAD_TIMEOUT_SECONDS,
+            )
+        if response.status_code not in (200, 204):
+            raise HarmonizeError(f"S3 upload failed ({response.status_code}): {response.text[:300]}")
+
+    def get_status(self, job_id: str, *, include_download_url: bool = False) -> dict[str, Any]:
+        """GET /retrieve-job-status/{job_id}, optionally requesting a presigned download URL."""
+        path = f"retrieve-job-status/{job_id}"
+        if include_download_url:
+            path += "?include_download_url=true"
+        return self._api_call("GET", path)
+
+    def download_results(self, download_url: str, output_path: Path) -> None:
+        """Fetch results from a presigned S3 URL and write them to output_path."""
+        logger.info("Downloading results to %s", output_path)
+        response = self.http.get(download_url, timeout=UPLOAD_TIMEOUT_SECONDS)
+        if response.status_code != 200:
+            raise HarmonizeError(f"Download failed ({response.status_code}): {response.text[:300]}")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(response.content)

--- a/src/dm_bip/ai_harmonize/client.py
+++ b/src/dm_bip/ai_harmonize/client.py
@@ -161,7 +161,16 @@ class Client:
         return self._api_call("POST", "submit-file", json_body=body)
 
     def upload_file(self, upload_url: str, path: Path, content_type: str) -> None:
-        """PUT a file to a presigned S3 URL — no auth header (URL is pre-signed)."""
+        """
+        PUT a file to a presigned S3 URL — no auth header (URL is pre-signed).
+
+        The body is buffered in memory rather than streamed. Input size is bounded by
+        study-variable-count × a small handful of metadata columns (~25MB worst case
+        for the largest BDC cohorts), well within comfortable in-memory limits on
+        any curator workstation. Streaming would require explicit Content-Length
+        handling to keep S3's presigned-URL signature valid; the complexity isn't
+        warranted at this scale. Revisit if input shape grows materially.
+        """
         logger.info("Uploading %s (%d bytes) to S3", path.name, path.stat().st_size)
         with path.open("rb") as fh:
             response = self.http.put(

--- a/src/dm_bip/ai_harmonize/config.py
+++ b/src/dm_bip/ai_harmonize/config.py
@@ -1,0 +1,38 @@
+"""Configuration for the AI harmonize client — env var resolution with sensible defaults."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_API_URL = "https://c0zz109oak.execute-api.us-east-1.amazonaws.com/dev"
+
+_XDG_CACHE_HOME = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+DEFAULT_CACHE_DIR = _XDG_CACHE_HOME / "dm-bip"
+
+
+@dataclass(frozen=True)
+class Config:
+    """Resolved configuration: API endpoint + cache directory paths."""
+
+    api_url: str
+    cache_dir: Path
+
+    @property
+    def token_cache_path(self) -> Path:
+        """Path to the cached JWT id-token JSON file."""
+        return self.cache_dir / "ai-harmonize-token.json"
+
+    @property
+    def job_manifest_dir(self) -> Path:
+        """Directory holding per-job manifest JSON files."""
+        return self.cache_dir / "ai-harmonize-jobs"
+
+
+def load_config() -> Config:
+    """Build a Config from environment variables, falling back to documented defaults."""
+    return Config(
+        api_url=os.environ.get("AI_HARMONIZE_API_URL", DEFAULT_API_URL).rstrip("/"),
+        cache_dir=Path(os.environ.get("AI_HARMONIZE_CACHE_DIR") or DEFAULT_CACHE_DIR),
+    )

--- a/src/dm_bip/ai_harmonize/storage.py
+++ b/src/dm_bip/ai_harmonize/storage.py
@@ -1,0 +1,86 @@
+"""Local persistence for the AI harmonize client: token cache + job manifests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CachedToken:
+    """A JWT id-token with its expiry (from the JWT's `exp` claim, or None if undecodable)."""
+
+    token: str
+    expires_at: float | None = None
+
+
+def load_token(path: Path) -> CachedToken | None:
+    """Load a cached token from disk; returns None if missing, unreadable, or malformed."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        expires_raw = data.get("expires_at")
+        return CachedToken(
+            token=data["token"],
+            expires_at=float(expires_raw) if expires_raw is not None else None,
+        )
+    except (json.JSONDecodeError, KeyError, ValueError, OSError) as exc:
+        logger.debug("Discarding unreadable token cache at %s: %s", path, exc)
+        return None
+
+
+def save_token(path: Path, token: CachedToken) -> None:
+    """Write a token to disk with restrictive (user-only) permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(token)))
+    os.chmod(path, 0o600)
+
+
+@dataclass
+class JobManifest:
+    """Local record of a submitted job — params, S3 keys, status snapshot."""
+
+    job_id: str
+    submitted_at: float
+    parameters: dict[str, Any]
+    s3_input_key: str | None = None
+    last_status: str | None = None
+    s3_output_path: str | None = None
+
+
+def save_manifest(manifest_dir: Path, manifest: JobManifest) -> Path:
+    """Persist a job manifest under `<manifest_dir>/<job_id>.json`; returns the path written."""
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    out = manifest_dir / f"{manifest.job_id}.json"
+    out.write_text(json.dumps(asdict(manifest), indent=2, sort_keys=True))
+    return out
+
+
+def load_manifest(manifest_dir: Path, job_id: str) -> JobManifest | None:
+    """Load a previously saved manifest by job_id; None if not found."""
+    path = manifest_dir / f"{job_id}.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return JobManifest(**data)
+
+
+def list_manifests(manifest_dir: Path) -> list[JobManifest]:
+    """Return all saved manifests sorted by submission time, newest first."""
+    if not manifest_dir.exists():
+        return []
+    manifests = []
+    for path in manifest_dir.glob("*.json"):
+        try:
+            manifests.append(JobManifest(**json.loads(path.read_text())))
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.debug("Skipping malformed manifest %s: %s", path, exc)
+    manifests.sort(key=lambda m: m.submitted_at, reverse=True)
+    return manifests

--- a/src/dm_bip/ai_harmonize/storage.py
+++ b/src/dm_bip/ai_harmonize/storage.py
@@ -64,12 +64,15 @@ def save_manifest(manifest_dir: Path, manifest: JobManifest) -> Path:
 
 
 def load_manifest(manifest_dir: Path, job_id: str) -> JobManifest | None:
-    """Load a previously saved manifest by job_id; None if not found."""
+    """Load a previously saved manifest by job_id; None if missing, unreadable, or malformed."""
     path = manifest_dir / f"{job_id}.json"
     if not path.exists():
         return None
-    data = json.loads(path.read_text())
-    return JobManifest(**data)
+    try:
+        return JobManifest(**json.loads(path.read_text()))
+    except (json.JSONDecodeError, TypeError, OSError) as exc:
+        logger.debug("Discarding unreadable manifest at %s: %s", path, exc)
+        return None
 
 
 def list_manifests(manifest_dir: Path) -> list[JobManifest]:
@@ -80,7 +83,7 @@ def list_manifests(manifest_dir: Path) -> list[JobManifest]:
     for path in manifest_dir.glob("*.json"):
         try:
             manifests.append(JobManifest(**json.loads(path.read_text())))
-        except (json.JSONDecodeError, TypeError) as exc:
-            logger.debug("Skipping malformed manifest %s: %s", path, exc)
+        except (json.JSONDecodeError, TypeError, OSError) as exc:
+            logger.debug("Skipping unreadable manifest %s: %s", path, exc)
     manifests.sort(key=lambda m: m.submitted_at, reverse=True)
     return manifests

--- a/src/dm_bip/cli.py
+++ b/src/dm_bip/cli.py
@@ -7,6 +7,7 @@ from typing import Annotated, Optional
 import typer
 
 from dm_bip import __version__
+from dm_bip.ai_harmonize.cli import app as ai_harmonize_app
 
 __all__ = [
     "app",
@@ -15,7 +16,11 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-app = typer.Typer(help="CLI for dm-bip.")
+app = typer.Typer(
+    help="CLI for dm-bip.",
+    epilog="For pipeline orchestration (schema generation, validation, mapping), use `make help`.",
+)
+app.add_typer(ai_harmonize_app, name="ai-harmonize")
 
 
 def version_callback(value: bool):

--- a/tests/unit/ai_harmonize/__init__.py
+++ b/tests/unit/ai_harmonize/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the ai_harmonize package."""

--- a/tests/unit/ai_harmonize/conftest.py
+++ b/tests/unit/ai_harmonize/conftest.py
@@ -1,0 +1,42 @@
+"""Shared fixtures for ai_harmonize unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from dm_bip.ai_harmonize import storage
+
+
+@pytest.fixture
+def harmonize_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the wrapper at a tmp cache dir and a stable API URL; returns the cache dir."""
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("AI_HARMONIZE_API_URL", "https://api.test.example/dev")
+    monkeypatch.setenv("AI_HARMONIZE_CACHE_DIR", str(cache_dir))
+    monkeypatch.delenv("AI_HARMONIZE_TOKEN", raising=False)
+    return cache_dir
+
+
+@pytest.fixture
+def sample_tsv(tmp_path: Path) -> Path:
+    """Create a tiny TSV file for upload tests."""
+    path = tmp_path / "vars.tsv"
+    path.write_text("name\tdescription\nbmi\tBody Mass Index\n")
+    return path
+
+
+@pytest.fixture
+def seed_token(harmonize_env: Path) -> Callable[[], None]:
+    """Return a callable that pre-populates the token cache so tests skip Cognito auth."""
+
+    def _seed() -> None:
+        token = "test-jwt"  # noqa: S105  (placeholder, not a real credential)
+        storage.save_token(
+            harmonize_env / "ai-harmonize-token.json",
+            storage.CachedToken(token=token, expires_at=None),
+        )
+
+    return _seed

--- a/tests/unit/ai_harmonize/test_cli_fetch.py
+++ b/tests/unit/ai_harmonize/test_cli_fetch.py
@@ -1,0 +1,60 @@
+"""Tests for `dm-bip ai-harmonize fetch`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from dm_bip.ai_harmonize.cli import app
+
+
+def test_fetch_downloads_results_when_job_completed(
+    harmonize_env: Path,  # noqa: ARG001
+    seed_token: Callable[[], None],
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Fetch should follow the download_url and write its contents to the requested output path."""
+    seed_token()
+    output_path = tmp_path / "results.csv"
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.example/dev/retrieve-job-status/job-1?include_download_url=true",
+        json={
+            "status": "completed",
+            "download_url": "https://s3.test.example/results.csv",
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.test.example/results.csv",
+        content=b"original,matched\nbmi,body_mass_index\n",
+    )
+
+    result = CliRunner().invoke(app, ["fetch", "job-1", "--output", str(output_path)])
+
+    assert result.exit_code == 0
+    assert output_path.read_bytes() == b"original,matched\nbmi,body_mass_index\n"
+
+
+def test_fetch_refuses_when_job_not_completed(
+    harmonize_env: Path,  # noqa: ARG001
+    seed_token: Callable[[], None],
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Fetch exits non-zero with a clear message when the job is still processing."""
+    seed_token()
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.example/dev/retrieve-job-status/job-1?include_download_url=true",
+        json={"status": "processing"},
+    )
+
+    result = CliRunner().invoke(app, ["fetch", "job-1", "--output", str(tmp_path / "x.csv")])
+
+    assert result.exit_code == 1
+    assert "not complete" in result.output.lower()

--- a/tests/unit/ai_harmonize/test_cli_list.py
+++ b/tests/unit/ai_harmonize/test_cli_list.py
@@ -1,0 +1,38 @@
+"""Tests for `dm-bip ai-harmonize list`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from dm_bip.ai_harmonize import storage
+from dm_bip.ai_harmonize.cli import app
+
+
+def test_list_when_empty(harmonize_env: Path) -> None:  # noqa: ARG001
+    """An empty manifest dir prints a friendly placeholder, not an error."""
+    result = CliRunner().invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert "no tracked jobs" in result.output.lower()
+
+
+def test_list_orders_newest_first_with_json_payload(harmonize_env: Path) -> None:
+    """--json emits the saved manifests as a JSON array, newest first."""
+    manifest_dir = harmonize_env / "ai-harmonize-jobs"
+    storage.save_manifest(
+        manifest_dir,
+        storage.JobManifest(job_id="old", submitted_at=100.0, parameters={"filename": "old.tsv"}),
+    )
+    storage.save_manifest(
+        manifest_dir,
+        storage.JobManifest(job_id="new", submitted_at=200.0, parameters={"filename": "new.tsv"}),
+    )
+
+    result = CliRunner().invoke(app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert [m["job_id"] for m in parsed] == ["new", "old"]

--- a/tests/unit/ai_harmonize/test_cli_set_token.py
+++ b/tests/unit/ai_harmonize/test_cli_set_token.py
@@ -1,0 +1,45 @@
+"""Tests for `dm-bip ai-harmonize set-token`."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from dm_bip.ai_harmonize import storage
+from dm_bip.ai_harmonize.cli import app
+
+
+def _make_jwt(claims: dict) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    return f"header.{payload}.signature"
+
+
+def test_set_token_decodes_expiry_and_writes_cache(harmonize_env: Path) -> None:
+    """A valid JWT lands in the cache with its `exp` claim parsed into expires_at."""
+    jwt = _make_jwt({"exp": 1700000000, "sub": "test-user"})
+
+    result = CliRunner().invoke(app, ["set-token", jwt])
+
+    assert result.exit_code == 0
+    assert "expires" in result.output.lower()
+
+    cached = storage.load_token(harmonize_env / "ai-harmonize-token.json")
+    assert cached is not None
+    assert cached.token == jwt
+    assert cached.expires_at == 1700000000.0
+
+
+def test_set_token_accepts_non_jwt_with_unknown_expiry(harmonize_env: Path) -> None:
+    """An opaque (non-JWT) token still gets cached; output flags the unknown expiry."""
+    result = CliRunner().invoke(app, ["set-token", "opaque-token-blob"])
+
+    assert result.exit_code == 0
+    assert "expiry could not be determined" in result.output.lower()
+
+    cached = storage.load_token(harmonize_env / "ai-harmonize-token.json")
+    assert cached is not None
+    assert cached.token == "opaque-token-blob"  # noqa: S105
+    assert cached.expires_at is None

--- a/tests/unit/ai_harmonize/test_cli_status.py
+++ b/tests/unit/ai_harmonize/test_cli_status.py
@@ -1,0 +1,62 @@
+"""Tests for `dm-bip ai-harmonize status`."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from dm_bip.ai_harmonize import storage
+from dm_bip.ai_harmonize.cli import app
+
+
+def test_status_prints_status_and_updates_manifest(
+    harmonize_env: Path,
+    seed_token: Callable[[], None],
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Status should print the API's status field and refresh the local manifest."""
+    seed_token()
+    manifest_dir = harmonize_env / "ai-harmonize-jobs"
+    storage.save_manifest(
+        manifest_dir,
+        storage.JobManifest(job_id="job-1", submitted_at=100.0, parameters={"colname": "desc"}),
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.example/dev/retrieve-job-status/job-1",
+        json={"status": "processing", "job_id": "job-1"},
+    )
+
+    result = CliRunner().invoke(app, ["status", "job-1"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "processing"
+
+    updated = storage.load_manifest(manifest_dir, "job-1")
+    assert updated is not None
+    assert updated.last_status == "processing"
+
+
+def test_status_with_json_flag_dumps_full_payload(
+    harmonize_env: Path,  # noqa: ARG001
+    seed_token: Callable[[], None],
+    httpx_mock: HTTPXMock,
+) -> None:
+    """--json emits the full API response, not just the status field."""
+    seed_token()
+    payload = {"status": "completed", "job_id": "job-2", "processing_time_seconds": 42.5}
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.example/dev/retrieve-job-status/job-2",
+        json=payload,
+    )
+
+    result = CliRunner().invoke(app, ["status", "job-2", "--json"])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed == payload

--- a/tests/unit/ai_harmonize/test_cli_submit.py
+++ b/tests/unit/ai_harmonize/test_cli_submit.py
@@ -1,0 +1,59 @@
+"""Happy-path test for `dm-bip ai-harmonize submit`."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from dm_bip.ai_harmonize.cli import app
+
+
+def test_submit_uploads_and_tracks_manifest(
+    harmonize_env: Path,
+    seed_token: Callable[[], None],
+    sample_tsv: Path,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Submit should request a presigned URL, PUT the file, and persist a manifest using the cached token."""
+    seed_token()
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.test.example/dev/submit-file",
+        json={
+            "job_id": "20260518_120000_abc",
+            "upload_url": "https://s3.test.example/presigned-upload",
+            "s3_key": "harmonization/inputs/20260518_120000_abc_vars.tsv",
+            "expires_in": 600,
+        },
+    )
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://s3.test.example/presigned-upload",
+        status_code=200,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["submit", str(sample_tsv), "--col", "description"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip().endswith("20260518_120000_abc")
+
+    manifest_path = harmonize_env / "ai-harmonize-jobs" / "20260518_120000_abc.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["job_id"] == "20260518_120000_abc"
+    assert manifest["parameters"]["colname"] == "description"
+    assert manifest["s3_input_key"] == "harmonization/inputs/20260518_120000_abc_vars.tsv"
+
+    submit_request = next(req for req in httpx_mock.get_requests() if req.url.path == "/dev/submit-file")
+    assert submit_request.headers["Authorization"] == "test-jwt"
+    submit_body = json.loads(submit_request.content)
+    assert submit_body["action"] == "get_upload_url"
+    assert submit_body["filename"] == "vars.tsv"
+    assert submit_body["colname"] == "description"

--- a/tests/unit/ai_harmonize/test_cli_wait.py
+++ b/tests/unit/ai_harmonize/test_cli_wait.py
@@ -1,0 +1,47 @@
+"""Tests for `dm-bip ai-harmonize wait`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from dm_bip.ai_harmonize.cli import app
+
+
+def test_wait_polls_until_completed(
+    harmonize_env: Path,  # noqa: ARG001
+    seed_token: Callable[[], None],
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Wait polls until the API reports a terminal status, then exits 0."""
+    seed_token()
+    url = "https://api.test.example/dev/retrieve-job-status/job-1"
+    httpx_mock.add_response(method="GET", url=url, json={"status": "processing"})
+    httpx_mock.add_response(method="GET", url=url, json={"status": "completed"})
+
+    result = CliRunner().invoke(app, ["wait", "job-1", "--interval", "0"])
+
+    assert result.exit_code == 0
+    assert "completed" in result.output
+
+
+def test_wait_exits_nonzero_on_failure(
+    harmonize_env: Path,  # noqa: ARG001
+    seed_token: Callable[[], None],
+    httpx_mock: HTTPXMock,
+) -> None:
+    """A terminal 'failed' status causes wait to exit 1 and surface the error_message."""
+    seed_token()
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.example/dev/retrieve-job-status/job-1",
+        json={"status": "failed", "error_message": "MongoDB connection refused"},
+    )
+
+    result = CliRunner().invoke(app, ["wait", "job-1", "--interval", "0"])
+
+    assert result.exit_code == 1
+    assert "MongoDB connection refused" in result.output

--- a/tests/unit/ai_harmonize/test_client.py
+++ b/tests/unit/ai_harmonize/test_client.py
@@ -1,0 +1,147 @@
+"""Tests for the Client: token sourcing, retry behavior, 401 handling, JWT decode."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from dm_bip.ai_harmonize import storage
+from dm_bip.ai_harmonize.client import (
+    TOKEN_REFRESH_HINT,
+    Client,
+    HarmonizeError,
+    TokenMissingError,
+    decode_jwt_expiry,
+)
+from dm_bip.ai_harmonize.config import load_config
+
+
+@pytest.fixture
+def client(harmonize_env: Path) -> Client:  # noqa: ARG001
+    """Construct a Client wired to the test env (harmonize_env applies the env vars)."""
+    return Client(load_config())
+
+
+def _make_jwt(claims: dict) -> str:
+    """Build a minimal-but-decodable JWT string (no signature; we only care about the payload)."""
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    return f"header.{payload}.signature"
+
+
+def test_decode_jwt_expiry_reads_exp_claim() -> None:
+    """decode_jwt_expiry returns the `exp` value from a valid JWT payload."""
+    jwt = _make_jwt({"exp": 1700000000, "sub": "anyone"})
+    assert decode_jwt_expiry(jwt) == 1700000000.0
+
+
+def test_decode_jwt_expiry_returns_none_for_non_jwt() -> None:
+    """A string that doesn't look like a JWT returns None instead of raising."""
+    assert decode_jwt_expiry("not-a-jwt") is None
+    assert decode_jwt_expiry("missing.exp_claim.sig") is None
+
+
+def test_get_token_prefers_env_var_over_cache(
+    client: Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If AI_HARMONIZE_TOKEN is set, it overrides whatever is in the cache file."""
+    storage.save_token(
+        client.config.token_cache_path,
+        storage.CachedToken(token="from-cache", expires_at=None),  # noqa: S106
+    )
+    monkeypatch.setenv("AI_HARMONIZE_TOKEN", "from-env")
+
+    assert client.get_token() == "from-env"
+
+
+def test_get_token_falls_back_to_cache(client: Client) -> None:
+    """With no env var set, get_token reads the cached token."""
+    storage.save_token(
+        client.config.token_cache_path,
+        storage.CachedToken(token="from-cache", expires_at=None),  # noqa: S106
+    )
+
+    assert client.get_token() == "from-cache"
+
+
+def test_get_token_raises_when_neither_env_nor_cache(client: Client) -> None:
+    """With no token anywhere, get_token raises a TokenMissingError pointing at set-token."""
+    with pytest.raises(TokenMissingError, match="set-token"):
+        client.get_token()
+
+
+def test_api_401_raises_with_token_refresh_hint(
+    client: Client,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """A 401 from any API endpoint surfaces the token-refresh hint via HarmonizeError."""
+    storage.save_token(
+        client.config.token_cache_path,
+        storage.CachedToken(token="stale", expires_at=None),  # noqa: S106
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.example/dev/retrieve-job-status/job-1",
+        status_code=401,
+        text="Unauthorized",
+    )
+
+    with pytest.raises(HarmonizeError) as excinfo:
+        client.get_status("job-1")
+    assert str(excinfo.value) == TOKEN_REFRESH_HINT
+
+
+def test_request_retries_on_transient_error_then_succeeds(
+    client: Client,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 503 from /submit-file is retried; subsequent 200 returns the parsed body."""
+    monkeypatch.setattr("dm_bip.ai_harmonize.client.time.sleep", lambda _: None)
+    storage.save_token(
+        client.config.token_cache_path,
+        storage.CachedToken(token="jwt", expires_at=None),  # noqa: S106
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.test.example/dev/submit-file",
+        status_code=503,
+        text="upstream busy",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.test.example/dev/submit-file",
+        json={"job_id": "j1", "upload_url": "https://s3/u", "s3_key": "k"},
+    )
+
+    result = client.request_upload_url(filename="x.tsv", colname="desc")
+
+    assert result["job_id"] == "j1"
+    assert len([r for r in httpx_mock.get_requests() if r.url.path == "/dev/submit-file"]) == 2
+
+
+def test_request_raises_after_retries_exhausted(
+    client: Client,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If 5xx persists past RETRY_MAX_ATTEMPTS, surface a HarmonizeError."""
+    monkeypatch.setattr("dm_bip.ai_harmonize.client.time.sleep", lambda _: None)
+    storage.save_token(
+        client.config.token_cache_path,
+        storage.CachedToken(token="jwt", expires_at=None),  # noqa: S106
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.test.example/dev/submit-file",
+        status_code=503,
+        text="upstream busy",
+        is_reusable=True,
+    )
+
+    with pytest.raises(HarmonizeError):
+        client.request_upload_url(filename="x.tsv", colname="desc")

--- a/tests/unit/ai_harmonize/test_config.py
+++ b/tests/unit/ai_harmonize/test_config.py
@@ -1,0 +1,41 @@
+"""Tests for the AI harmonize config loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dm_bip.ai_harmonize.config import DEFAULT_API_URL, DEFAULT_CACHE_DIR, load_config
+
+
+def test_load_config_uses_defaults_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """API URL and cache dir fall back to documented defaults when no env overrides are set."""
+    monkeypatch.delenv("AI_HARMONIZE_API_URL", raising=False)
+    monkeypatch.delenv("AI_HARMONIZE_CACHE_DIR", raising=False)
+
+    config = load_config()
+
+    assert config.api_url == DEFAULT_API_URL
+    assert config.cache_dir == DEFAULT_CACHE_DIR
+
+
+def test_load_config_respects_env_overrides(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Both endpoint and cache location accept env overrides."""
+    monkeypatch.setenv("AI_HARMONIZE_API_URL", "https://override.example/v1/")
+    monkeypatch.setenv("AI_HARMONIZE_CACHE_DIR", str(tmp_path))
+
+    config = load_config()
+
+    assert config.api_url == "https://override.example/v1"  # trailing slash stripped
+    assert config.cache_dir == tmp_path
+
+
+def test_config_derives_token_and_manifest_paths(tmp_path: Path) -> None:
+    """The cache_dir drives the locations of the token cache and manifest dir."""
+    from dm_bip.ai_harmonize.config import Config
+
+    config = Config(api_url="https://x", cache_dir=tmp_path)
+
+    assert config.token_cache_path == tmp_path / "ai-harmonize-token.json"
+    assert config.job_manifest_dir == tmp_path / "ai-harmonize-jobs"

--- a/tests/unit/ai_harmonize/test_storage.py
+++ b/tests/unit/ai_harmonize/test_storage.py
@@ -1,0 +1,88 @@
+"""Tests for the token cache and job manifest storage layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dm_bip.ai_harmonize.storage import (
+    CachedToken,
+    JobManifest,
+    list_manifests,
+    load_manifest,
+    load_token,
+    save_manifest,
+    save_token,
+)
+
+
+def test_token_roundtrip_preserves_value_and_expiry(tmp_path: Path) -> None:
+    """save_token then load_token returns an equivalent CachedToken."""
+    path = tmp_path / "token.json"
+    token = CachedToken(token="jwt-value", expires_at=1_700_000_000.0)  # noqa: S106
+
+    save_token(path, token)
+    loaded = load_token(path)
+
+    assert loaded is not None
+    assert loaded.token == token.token
+    assert loaded.expires_at == token.expires_at
+
+
+def test_token_roundtrip_handles_unknown_expiry(tmp_path: Path) -> None:
+    """A token saved with expires_at=None round-trips correctly (graceful JWT-decode fallback)."""
+    path = tmp_path / "token.json"
+    save_token(path, CachedToken(token="opaque", expires_at=None))  # noqa: S106
+
+    loaded = load_token(path)
+
+    assert loaded is not None
+    assert loaded.token == "opaque"  # noqa: S105
+    assert loaded.expires_at is None
+
+
+def test_load_token_returns_none_for_missing_or_malformed(tmp_path: Path) -> None:
+    """Missing or unreadable token files yield None rather than raising."""
+    assert load_token(tmp_path / "missing.json") is None
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("not-json")
+    assert load_token(bad) is None
+
+
+def test_manifest_roundtrip(tmp_path: Path) -> None:
+    """save_manifest then load_manifest preserves all fields."""
+    manifest = JobManifest(
+        job_id="job-1",
+        submitted_at=123456.0,
+        parameters={"colname": "description"},
+        s3_input_key="inputs/job-1.tsv",
+        last_status="processing",
+        s3_output_path=None,
+    )
+
+    save_manifest(tmp_path, manifest)
+    loaded = load_manifest(tmp_path, "job-1")
+
+    assert loaded == manifest
+
+
+def test_list_manifests_sorts_newest_first(tmp_path: Path) -> None:
+    """list_manifests returns manifests ordered by submitted_at descending."""
+    save_manifest(tmp_path, JobManifest(job_id="old", submitted_at=100.0, parameters={}))
+    save_manifest(tmp_path, JobManifest(job_id="new", submitted_at=200.0, parameters={}))
+    save_manifest(tmp_path, JobManifest(job_id="mid", submitted_at=150.0, parameters={}))
+
+    listed = list_manifests(tmp_path)
+
+    assert [m.job_id for m in listed] == ["new", "mid", "old"]
+
+
+def test_list_manifests_skips_malformed_files(tmp_path: Path) -> None:
+    """A non-JSON file in the manifest dir doesn't break list_manifests."""
+    save_manifest(tmp_path, JobManifest(job_id="good", submitted_at=100.0, parameters={}))
+    (tmp_path / "broken.json").write_text("{not json")
+
+    listed = list_manifests(tmp_path)
+
+    assert len(listed) == 1
+    assert listed[0].job_id == "good"

--- a/uv.lock
+++ b/uv.lock
@@ -755,6 +755,7 @@ name = "dm-bip"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "linkml-map" },
     { name = "pandas" },
     { name = "schema-automator" },
@@ -771,6 +772,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-httpx" },
     { name = "ruff" },
 ]
 docs = [
@@ -784,6 +786,7 @@ env = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "linkml-map", specifier = "==0.5.2" },
     { name = "pandas", specifier = ">=2.2.3,<3" },
     { name = "schema-automator", specifier = "==0.5.5" },
@@ -800,6 +803,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.3.3" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-httpx", specifier = ">=0.30,<1" },
     { name = "ruff", specifier = ">=0.12.9" },
 ]
 docs = [
@@ -3227,6 +3231,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146, upload-time = "2024-11-28T19:16:54.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442, upload-time = "2024-11-28T19:16:52.787Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **Parked (draft, staged):** target API decommissioned by RTI; pivoting beachhead to `seven_bridges` while awaiting James's new pipeline spec. See latest comment.

## Summary

Adds `dm-bip ai-harmonize` (verbs: `set-token`, `submit`, `status`, `fetch`, `wait`, `list`) wrapping RTI's hosted variable-harmonization API.

Token-based: users obtain a JWT externally (`aws cognito-idp initiate-auth`, browser flow, however they like) and cache it via `set-token`. The wrapper isn't in the credential-management business — it reads tokens from `AI_HARMONIZE_TOKEN` env var or `~/.cache/dm-bip/ai-harmonize-token.json`, decodes the `exp` claim for expiry diagnostics, and surfaces a clear "refresh your token" message on 401s.

Closes #199.

## Verb-group beachhead

This is also the first step in unifying dm-bip's growing set of entry points under one CLI. Today the repo has 13 user-invokable entry points across 4 invocation patterns (Typer verbs, `python -m`, script-paths, shell scripts). The AI harmonize tool is the first verb-group; SBG suite and other stateful tools migrate opportunistically.

Make stays as the pipeline orchestrator. The CLI consolidates individual-operation entry points. Two reciprocal discoverability hooks added:
- `dm-bip --help` epilog points at `make help` for pipeline orchestration
- `pipeline.Makefile` HELP block points at `dm-bip --help` for individual operations

## Why staged

Authenticated requests to the live dev API consistently return 500 `{"message":"Internal server error"}` — confirmed both via the wrapper and via direct `curl` with the same token. Unauthenticated requests return a clean 401, so the endpoint is reachable but something is broken server-side (Lambda authorizer or downstream).

Cannot verify the wrapper end-to-end until Stephen/James (the tool's implementors) confirm the API is healthy. The wrapper is implementation-complete with 28 unit tests; it should work once the API does.

## Test plan

- [x] `make test` passes (191 tests, 28 new)
- [x] `make lint` clean (pre-existing notebook issues unchanged)
- [x] `make format --check` clean
- [ ] Smoke test against live RTI API — **blocked** on server-side investigation
