### PR TITLE
Diagnostics toggle, unpinned app default, and :prod promotion tag

### DIFF
--- a/.github/workflows/docker-push-7bridges-dev.yml
+++ b/.github/workflows/docker-push-7bridges-dev.yml
@@ -53,9 +53,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ vars.SB_REGISTRY }}/${{ vars.SB_REGISTRY_USERNAME }}/${{ steps.build-config.outputs.registry_project }}/${{ env.IMAGE_NAME }}
+          # The :prod tag is a promotion pointer — the prod app pulls it permanently, so
+          # a release deploys by moving the tag rather than by hand-editing the app. It is
+          # guarded against pre-release tags so an rc can never become prod.
           tags: |
             type=raw,value=latest
             type=match,pattern=bdc-v.*,enable=${{ startsWith(github.ref, 'refs/tags/bdc-v') }}
+            type=raw,value=prod,enable=${{ startsWith(github.ref, 'refs/tags/bdc-v') && !contains(github.ref, '-rc') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,28 @@
 # Release Process
 
+## Choosing a Version Number
+
+A version protects a *contract*. Each number answers "what happens if someone pulls this?"
+
+dm-bip's contract is not a code API — nobody imports it. It is two things:
+
+1. **Operating interface** — how you invoke and deploy: Make targets, `DM_*` config variables, CLI verbs, container inputs. Operators depend on this.
+2. **Output** — the shape of the harmonized data and its BDCHM conformance. Downstream data consumers depend on this.
+
+Work through these in order:
+
+| | Test | Result |
+|---|---|---|
+| 1 | Must an operator change how they invoke or deploy, or a consumer change how they read output? | **Major** — bump 1st, zero the rest |
+| 2 | Else, is there anything new they *can* use? | **Minor** — bump 2nd, zero the 3rd |
+| 3 | Else — fixes, safer dependencies, performance, docs? | **Patch** — bump 3rd |
+
+A bug fix that *changes* output for the broken cases is still a patch: the contract was always "be correct," and the code just met it. Only escalate if you are changing what correct means.
+
+**Tempo.** Patches are low-ceremony and frequent, with no RC cycle — adopting one should be a no-brainer. Minors are batched and deliberate, and earn an RC cycle because there is new behavior worth exercising. Majors are rare, announced, and always get an RC.
+
+Cut patches eagerly. The anti-pattern is letting fixes and behavior-neutral dependency bumps pile up until they ride into the next minor, which wastes the third number's signal.
+
 ## GitHub Releases
 
 1. Create release candidate tags (`v<X.Y.Z>-rc<N>`) for testing.
@@ -51,10 +74,19 @@ git push origin bdc-v1.2.0
 
 ## Seven Bridges App Setup
 
-Each deployment tier should have a corresponding app on the Seven Bridges platform. The app's Docker Repository field should point to the appropriate registry path:
+Each deployment tier has a corresponding app on the Seven Bridges platform, whose Docker Repository field points at a registry path:
 
 ```
-<SB_REGISTRY>/<SB_REGISTRY_USERNAME>/<REGISTRY_PROJECT>/dm-bip-env
+<SB_REGISTRY>/<SB_REGISTRY_USERNAME>/<REGISTRY_PROJECT>/dm-bip-env:<TAG>
 ```
 
-When a new image is pushed, update the app revision to pick up the change.
+| App | Pulls | Moves when |
+|-----|-------|------------|
+| `cc-dm-bip-test` (dev) | `dm-bip-docker-dev/dm-bip-env:latest` | every push to `docker-dev` |
+| `bdc-dm-bip-prod` (prod) | `dm-bip-prod/dm-bip-env:prod` | a non-rc `bdc-v*` tag is pushed |
+
+**Prod deploys by moving a tag, not by editing the app.** The `:prod` tag is a promotion pointer: pushing `bdc-v<X.Y.Z>` builds the image, tags it both `bdc-v<X.Y.Z>` and `prod`, and the app picks it up on its next run. Pre-release tags containing `-rc` are excluded from `:prod`, so a release candidate can never become production.
+
+This means the app definition does not record which version prod is running. That is recoverable: every run writes `version`, `git_ref`, and `build_date` into its provenance output. To roll back, re-push `:prod` pointing at the older image rather than editing the app.
+
+Referencing an app without a trailing revision number resolves to its latest revision, so app revisions can change without breaking clients. `dm-bip seven-bridges submit --app <id>/<N>` still pins an explicit revision when you need one for testing.

--- a/src/dm_bip/seven_bridges/cli.py
+++ b/src/dm_bip/seven_bridges/cli.py
@@ -141,6 +141,10 @@ def submit(
     throttle: Annotated[
         int, typer.Option("--throttle", min=0, help="Seconds between task submissions.")
     ] = DEFAULT_THROTTLE_SECONDS,
+    profile: Annotated[
+        bool,
+        typer.Option("--profile", help="Enable map-step diagnostics (py-spy + cgroup) via the app's Profile toggle."),
+    ] = False,
 ) -> None:
     """Read the manifest CSV and launch one harmonization task per row, throttled."""
     if not manifest_path.exists():
@@ -197,6 +201,7 @@ def submit(
                 "Schema": schema,
                 "RawSource": {"class": "Directory", "path": folder["id"]},
                 **({"TransSpec": trans_spec} if trans_spec else {}),
+                **({"Profile": True} if profile else {}),
             },
         }
         try:

--- a/src/dm_bip/seven_bridges/client.py
+++ b/src/dm_bip/seven_bridges/client.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2"
 DEFAULT_PROJECT = "rmathur2/dmc-task-4-controlled"
-DEFAULT_APP = "rmathur2/dmc-task-4-controlled/cc-dm-bip-test/4"
+DEFAULT_APP = "rmathur2/dmc-task-4-controlled/cc-dm-bip-test/6"
 DEFAULT_TOKEN_FILE = Path.home() / ".sevenbridges" / "token"
 
 DEFAULT_TIMEOUT_SECONDS = 30.0

--- a/src/dm_bip/seven_bridges/client.py
+++ b/src/dm_bip/seven_bridges/client.py
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2"
 DEFAULT_PROJECT = "rmathur2/dmc-task-4-controlled"
-DEFAULT_APP = "rmathur2/dmc-task-4-controlled/cc-dm-bip-test/6"
+# No trailing revision: SBG resolves a bare app id to the latest revision, so this
+# default stops going stale every time the app is re-saved. Pin a revision for testing
+# with --app .../cc-dm-bip-test/<N> or SBG_DEFAULT_APP.
+DEFAULT_APP = "rmathur2/dmc-task-4-controlled/cc-dm-bip-test"
 DEFAULT_TOKEN_FILE = Path.home() / ".sevenbridges" / "token"
 
 DEFAULT_TIMEOUT_SECONDS = 30.0

--- a/tests/unit/seven_bridges/test_cli_submit.py
+++ b/tests/unit/seven_bridges/test_cli_submit.py
@@ -71,6 +71,7 @@ def test_submit_creates_and_runs_one_task_per_row(
     assert body["inputs"]["Schema"] == "FHS"
     assert body["inputs"]["RawSource"] == {"class": "Directory", "path": "group-id"}
     assert "TransSpec" not in body["inputs"]
+    assert "Profile" not in body["inputs"]
 
 
 def test_submit_passes_trans_spec_when_provided(
@@ -110,6 +111,42 @@ def test_submit_passes_trans_spec_when_provided(
     assert result.exit_code == 0
     create_req = next(r for r in httpx_mock.get_requests() if r.method == "POST" and r.url.path == "/v2/tasks")
     assert json.loads(create_req.content)["inputs"]["TransSpec"] == "OWNER/REPO@main:specs/foo"
+
+
+def test_submit_passes_profile_when_provided(
+    sbg_env: Path,  # noqa: ARG001
+    seed_token: Callable[[], None],
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """--profile adds the Profile input to the task body."""
+    seed_token()
+    manifest = tmp_path / "tasks.csv"
+    _write_manifest(manifest, [("phs000280-HMB-IRB", "ARIC")])
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.sbg.test/v2/files?project=test/project",
+        json={"items": [{"id": "root1", "name": "PilotParentStudies_NoDRS", "type": "folder"}]},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.sbg.test/v2/files?parent=root1",
+        json={"items": [{"id": "aric-id", "name": "ARIC", "type": "folder"}]},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.sbg.test/v2/files?parent=aric-id&name=phs000280-HMB-IRB",
+        json={"items": [{"id": "g-id", "name": "phs000280-HMB-IRB", "type": "folder"}]},
+    )
+    httpx_mock.add_response(method="POST", url="https://api.sbg.test/v2/tasks", json={"id": "t3"})
+    httpx_mock.add_response(method="POST", url="https://api.sbg.test/v2/tasks/t3/actions/run", json={"id": "t3"})
+
+    result = CliRunner().invoke(app, ["submit", "--manifest", str(manifest), "--throttle", "0", "--profile"])
+
+    assert result.exit_code == 0, result.output
+    create_req = next(r for r in httpx_mock.get_requests() if r.method == "POST" and r.url.path == "/v2/tasks")
+    assert json.loads(create_req.content)["inputs"]["Profile"] is True
 
 
 def test_submit_errors_when_manifest_missing(sbg_env: Path, tmp_path: Path) -> None:  # noqa: ARG001


### PR DESCRIPTION
Completes the diagnostics pass-through. `dm-bip seven-bridges submit --profile` sets the `Profile` input on app rev 6 (a boolean toggle bound to `--profile`), which flows to `bdc-workflow.sh` → `DM_MAP_PROFILE=true` → py-spy + cgroup. Default app bumped to `/6` (adds the optional toggle, default off — identical to /5 otherwise, so normal runs are unaffected). One app, one flag, no revision-juggling.