### PR TITLE
Validate mapped output against the target schema (advisory)

### DIFF
--- a/pipeline.Makefile
+++ b/pipeline.Makefile
@@ -53,6 +53,9 @@ DM_MAP_STRICT ?= true
 # peak memory / OOM counters are logged. Off by default; zero cost when off.
 DM_MAP_PROFILE ?= false
 DM_VALIDATE_STRICT ?=
+# Max records checked per entity when validating mapped output against the target
+# schema (0 = all). Bound this on large datasets to keep the advisory report cheap.
+DM_VALIDATE_OUTPUT_LIMIT ?= 0
 
 # --- Raw Data Preparation Variables ---
 # The raw directory containing .txt.gz files
@@ -98,6 +101,8 @@ SCHEMA_VALIDATE_LOG         := $(VALIDATE_OUTPUT_DIR)/$(DM_SCHEMA_NAME)-schema-v
 DATA_VALIDATE_FILES_DIR     := $(VALIDATE_OUTPUT_DIR)/data-validation
 DATA_VALIDATE_ERRORS_DIR    := $(VALIDATE_OUTPUT_DIR)/data-validation-errors
 MAPPING_LOG_DIR             := $(MAPPING_OUTPUT_DIR)/logs
+
+OUTPUT_VALIDATE_REPORT      := $(VALIDATE_OUTPUT_DIR)/$(DM_SCHEMA_NAME)-output-validation.txt
 
 VALIDATION_SUCCESS_SENTINEL := $(VALIDATE_OUTPUT_DIR)/_data_validation_complete
 MAPPING_SUCCESS_SENTINEL := $(MAPPING_OUTPUT_DIR)/_mapping_complete
@@ -169,6 +174,7 @@ Configured variables:
   DM_ENUM_THRESHOLD  = $(DM_ENUM_THRESHOLD)
   DM_MAX_ENUM_SIZE   = $(DM_MAX_ENUM_SIZE)
   DM_VALIDATE_STRICT = $(DM_VALIDATE_STRICT)
+  DM_VALIDATE_OUTPUT_LIMIT = $(DM_VALIDATE_OUTPUT_LIMIT)
 
 Generated variables
   input files:                    $(if $(INPUT_FILES),$(INPUT_FILES),(none))
@@ -180,6 +186,7 @@ Generated logs:
   data validation logs by file:   $(DATA_VALIDATE_FILES_DIR)
   data validation errors by file: $(DATA_VALIDATE_ERRORS_DIR)
   mapping logs:                   $(MAPPING_LOG_DIR)
+  output validation report:       $(OUTPUT_VALIDATE_REPORT)
 
 endef
 
@@ -233,7 +240,9 @@ help::
 .DEFAULT_GOAL := pipeline
 
 .PHONY: pipeline
-pipeline: $(MAPPING_SUCCESS_SENTINEL)
+# The advisory output-validation report is the endpoint when a target schema is
+# configured; without one there is nothing to validate against, so mapping is the end.
+pipeline: $(if $(DM_MAP_TARGET_SCHEMA),$(OUTPUT_VALIDATE_REPORT),$(MAPPING_SUCCESS_SENTINEL))
 
 .PHONY: pipeline-debug
 pipeline-debug:
@@ -635,6 +644,38 @@ $(MAPPING_OUTPUT_DIR)/.%_complete: $(MAP_TRANS_SPEC_FILES) $(SCHEMA_FILE) $(MAP_
 		exit $$rc; \
 	fi
 	@touch $@
+
+# Output Validation Goals
+# =======================
+#
+# The map step passes `--target-schema` to linkml-map, but that only shapes the
+# transformation — nothing asserts the emitted records actually conform to it. This
+# step validates mapped output against the target schema and writes a report.
+#
+# ADVISORY ONLY: the report never fails the pipeline. `validate_output` always exits
+# 0, so mapped output that does not conform is reported, not blocked. Enforcement is
+# a separate decision to be made once the real failure profile is known.
+#
+# Set DM_VALIDATE_OUTPUT_LIMIT to cap records checked per entity on large datasets.
+
+.PHONY: validate-output
+validate-output: $(OUTPUT_VALIDATE_REPORT)
+
+$(OUTPUT_VALIDATE_REPORT): $(MAPPING_SUCCESS_SENTINEL) $(MAP_TARGET_SCHEMA_FILE)
+	@mkdir -p $(VALIDATE_OUTPUT_DIR)
+	$(RUN) python -m dm_bip.map_data.validate_output \
+		--target-schema "$(MAP_TARGET_SCHEMA_FILE)" \
+		--mapped-dir $(MAPPING_OUTPUT_DIR) \
+		--entity-list $(_ENTITY_LIST_FILE) \
+		--prefix="$(DM_MAPPING_PREFIX)" \
+		--postfix="$(DM_MAPPING_POSTFIX)" \
+		--format $(_MAP_PRIMARY_FMT) \
+		--limit $(DM_VALIDATE_OUTPUT_LIMIT) \
+		--report $@
+
+.PHONY: validate-output-clean
+validate-output-clean:
+	rm -f $(OUTPUT_VALIDATE_REPORT)
 
 .PHONY: map-debug
 map-debug:

--- a/src/dm_bip/map_data/validate_output.py
+++ b/src/dm_bip/map_data/validate_output.py
@@ -1,0 +1,369 @@
+"""
+Validate mapped output against the target schema and write an advisory report.
+
+The map step hands ``linkml-map`` a ``--target-schema``, but that schema only shapes
+the transformation — nothing downstream asserts that the emitted records actually
+conform to it. This module closes that gap by validating the mapped output and
+summarizing what it finds.
+
+The report is advisory: this module always exits 0, so a failing report never breaks
+a pipeline run. Findings are aggregated by (entity, slot path, constraint) rather than
+listed per record, because a single systematic mismatch can affect every row and a
+per-record dump would be unreadable at real data volumes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+
+# NB: a Validator built without plugins runs no checks at all and reports everything
+# as valid. The plugin list below is what makes this validation real.
+VALIDATION_PLUGINS = [JsonschemaValidationPlugin(closed=True)]
+
+STRUCTURED_SUFFIXES = {".yaml", ".yml", ".json", ".jsonl"}
+
+MAX_EXAMPLES_PER_ISSUE = 3
+
+
+@dataclass
+class Issue:
+    """One aggregated conformance finding, counted across all records of an entity."""
+
+    slot_path: str
+    constraint: str
+    expected: str
+    count: int = 0
+    examples: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EntityReport:
+    """Validation outcome for a single mapped entity file."""
+
+    entity: str
+    path: Path
+    total_records: int = 0
+    checked_records: int = 0
+    invalid_records: int = 0
+    issues: dict[tuple[str, str, str], Issue] = field(default_factory=dict)
+    skipped_reason: str = ""
+
+    @property
+    def is_clean(self) -> bool:
+        """True when records were actually checked and all of them conformed."""
+        return self.checked_records > 0 and self.invalid_records == 0 and not self.skipped_reason
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    """
+    Read mapped output into a flat list of record dicts.
+
+    ``linkml-map`` has emitted more than one YAML shape across versions, so all are
+    handled: a multi-document stream (``---`` between records), and a collection under
+    a single pluralized container key (``participants:``, ``demographys:``) that the
+    target schema does not define and which is stripped before validating.
+
+    Args:
+        path: Mapped output file (``.yaml``, ``.yml``, ``.json``, or ``.jsonl``).
+
+    Returns:
+        List of record dicts; empty when the file holds no records.
+
+    """
+    if path.suffix == ".jsonl":
+        records = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+        return [r for r in records if isinstance(r, dict)]
+
+    if path.suffix == ".json":
+        doc = json.loads(path.read_text())
+    else:
+        docs = [d for d in yaml.safe_load_all(path.read_text()) if d is not None]
+        if len(docs) > 1:
+            # Multi-document stream: one record per document.
+            return [d for d in docs if isinstance(d, dict)]
+        doc = docs[0] if docs else None
+
+    if doc is None:
+        return []
+    if isinstance(doc, list):
+        return [r for r in doc if isinstance(r, dict)]
+    if isinstance(doc, dict):
+        # Single container key wrapping the collection.
+        if len(doc) == 1:
+            (inner,) = doc.values()
+            if isinstance(inner, list):
+                return [r for r in inner if isinstance(r, dict)]
+        # Otherwise treat the document itself as one record.
+        return [doc]
+    return []
+
+
+def normalize_slot_path(slot_path: str) -> str:
+    """
+    Collapse array indices in a JSON path so findings aggregate across list elements.
+
+    ``$.observations[0].value`` and ``$.observations[1].value`` describe the same
+    systematic problem. Without this, a multivalued slot produces one finding per
+    index and the report degenerates back into a per-record dump.
+
+    Args:
+        slot_path: JSON path from the validator, e.g. ``$.observations[3].value``.
+
+    Returns:
+        Path with numeric indices replaced by ``[*]``.
+
+    """
+    return re.sub(r"\[\d+\]", "[*]", slot_path)
+
+
+def issue_key(result: Any) -> tuple[str, str, str]:
+    """
+    Derive a stable (slot_path, constraint, expected) key for aggregating a result.
+
+    Prefers the structured jsonschema error carried on ``result.source``; falls back to
+    the human-readable message when a plugin does not supply one.
+
+    Args:
+        result: A ``ValidationResult`` from the linkml validator.
+
+    Returns:
+        Tuple identifying the kind of finding, independent of the offending value.
+
+    """
+    source = getattr(result, "source", None)
+    slot_path = getattr(source, "json_path", None)
+    constraint = getattr(source, "validator", None)
+    expected = getattr(source, "validator_value", None)
+
+    if slot_path is None:
+        return ("<unknown>", "unknown", str(result.message))
+    return (normalize_slot_path(str(slot_path)), str(constraint), str(expected))
+
+
+def validate_file(entity: str, path: Path, validator: Validator, limit: int = 0) -> EntityReport:
+    """
+    Validate one mapped entity file against the target schema.
+
+    Args:
+        entity: Target-schema class name to validate records against.
+        path: Mapped output file.
+        validator: Configured linkml ``Validator``.
+        limit: Maximum records to check; ``0`` checks all of them.
+
+    Returns:
+        Aggregated :class:`EntityReport` for the file.
+
+    """
+    report = EntityReport(entity=entity, path=path)
+
+    if not path.exists():
+        report.skipped_reason = "file not found"
+        return report
+    if path.suffix not in STRUCTURED_SUFFIXES:
+        report.skipped_reason = f"unsupported format '{path.suffix}' (needs yaml, json, or jsonl)"
+        return report
+
+    records = load_records(path)
+    if not records:
+        # An empty output file means the map step produced nothing for this entity.
+        # That is a failure signal, never a clean pass.
+        report.skipped_reason = "no records in output (map step produced an empty file)"
+        return report
+
+    report.total_records = len(records)
+    if limit > 0:
+        records = records[:limit]
+    report.checked_records = len(records)
+
+    for record in records:
+        results = list(validator.validate(record, target_class=entity).results)
+        if not results:
+            continue
+        report.invalid_records += 1
+        for result in results:
+            key = issue_key(result)
+            issue = report.issues.get(key)
+            if issue is None:
+                issue = Issue(slot_path=key[0], constraint=key[1], expected=key[2])
+                report.issues[key] = issue
+            issue.count += 1
+            if len(issue.examples) < MAX_EXAMPLES_PER_ISSUE:
+                issue.examples.append(str(result.message))
+
+    return report
+
+
+def render_report(reports: list[EntityReport], target_schema: Path, limit: int) -> str:
+    """
+    Render the aggregated findings as a plain-text report.
+
+    Args:
+        reports: Per-entity validation outcomes.
+        target_schema: Schema the output was validated against.
+        limit: Per-entity record cap that was applied (``0`` means all).
+
+    Returns:
+        The formatted report body.
+
+    """
+    lines: list[str] = []
+    lines.append("Mapped Output Validation Report")
+    lines.append("=" * 60)
+    lines.append(f"Target schema: {target_schema}")
+    lines.append(f"Record limit:  {limit if limit > 0 else 'none (all records)'}")
+    lines.append("")
+    lines.append("This report is advisory and does not fail the pipeline.")
+    lines.append("")
+
+    total_checked = sum(r.checked_records for r in reports)
+    total_invalid = sum(r.invalid_records for r in reports)
+
+    lines.append("Summary")
+    lines.append("-" * 60)
+    for report in reports:
+        if report.skipped_reason:
+            lines.append(f"  {report.entity:<32} SKIPPED — {report.skipped_reason}")
+            continue
+        pct = (report.invalid_records / report.checked_records * 100) if report.checked_records else 0.0
+        status = "ok" if report.is_clean else "FAIL"
+        lines.append(
+            f"  {report.entity:<32} {report.checked_records:>7} checked  "
+            f"{report.invalid_records:>7} invalid ({pct:5.1f}%)  [{status}]"
+        )
+    lines.append("")
+    overall = (total_invalid / total_checked * 100) if total_checked else 0.0
+    lines.append(f"  {'TOTAL':<32} {total_checked:>7} checked  {total_invalid:>7} invalid ({overall:5.1f}%)")
+    lines.append("")
+
+    reports_with_issues = [r for r in reports if r.issues]
+    if not reports_with_issues:
+        lines.append("No conformance issues found.")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append("Findings by entity")
+    lines.append("-" * 60)
+    for report in reports_with_issues:
+        lines.append(f"{report.entity}  ({report.path})")
+        for issue in sorted(report.issues.values(), key=lambda i: i.count, reverse=True):
+            lines.append(f"    {issue.count:>7}x  {issue.slot_path}  [{issue.constraint}: expected {issue.expected}]")
+            for example in issue.examples:
+                lines.append(f"             e.g. {example}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def read_entity_list(path: Path) -> list[str]:
+    """
+    Read entity names from the list written by the map step.
+
+    Args:
+        path: File holding one entity name per line.
+
+    Returns:
+        Entity names, or ``[]`` when the file is missing or empty.
+
+    """
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def entity_output_path(mapped_dir: Path, entity: str, prefix: str = "", postfix: str = "", fmt: str = "yaml") -> Path:
+    """
+    Rebuild the mapped output path for an entity.
+
+    Mirrors the ``_map_base`` function in ``pipeline.Makefile``, which names outputs
+    ``{prefix}-{entity}-{postfix}.{fmt}`` while omitting empty parts.
+
+    Args:
+        mapped_dir: Directory holding mapped output.
+        entity: Entity (target class) name.
+        prefix: Optional filename prefix.
+        postfix: Optional filename postfix.
+        fmt: Output format suffix.
+
+    Returns:
+        Path to the entity's mapped output file.
+
+    """
+    parts = [part for part in (prefix, entity, postfix) if part]
+    return mapped_dir / f"{'-'.join(parts)}.{fmt}"
+
+
+def _emit(body: str, report_path: Path | None) -> None:
+    """Write the report to ``report_path``, or to stdout when no path is given."""
+    if report_path:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(body)
+        print(f"Output validation report written to {report_path}")
+    else:
+        print(body)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Always returns 0 — this validation is advisory."""
+    parser = argparse.ArgumentParser(
+        prog="validate_output",
+        description="Validate mapped output against the target schema (advisory; never fails).",
+    )
+    parser.add_argument("--target-schema", required=True, type=Path, help="Target schema to validate against")
+    parser.add_argument("--mapped-dir", required=True, type=Path, help="Directory holding mapped output")
+    parser.add_argument("--entity-list", required=True, type=Path, help="File listing one entity name per line")
+    parser.add_argument("--prefix", default="", help="Mapped output filename prefix")
+    parser.add_argument("--postfix", default="", help="Mapped output filename postfix")
+    parser.add_argument("--format", default="yaml", help="Mapped output format suffix (default: yaml)")
+    parser.add_argument("--report", type=Path, help="Write the report here (default: stdout)")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Max records to check per entity (0 = all). Use to bound runtime on large datasets.",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    # Skips still emit a report, so the reason is recorded and Make sees the target built.
+    skip_reason = ""
+    if not str(args.target_schema):
+        skip_reason = "No target schema configured (DM_MAP_TARGET_SCHEMA is unset)."
+    elif not args.target_schema.exists():
+        skip_reason = f"Target schema not found: {args.target_schema}"
+
+    entities = [] if skip_reason else read_entity_list(args.entity_list)
+    if not skip_reason and not entities:
+        skip_reason = f"No entities listed in {args.entity_list}"
+
+    if skip_reason:
+        body = f"Mapped Output Validation Report\n{'=' * 60}\nSkipped — {skip_reason}\n"
+        _emit(body, args.report)
+        return 0
+
+    validator = Validator(str(args.target_schema), validation_plugins=VALIDATION_PLUGINS)
+
+    reports = []
+    for entity in entities:
+        path = entity_output_path(args.mapped_dir, entity, args.prefix, args.postfix, args.format)
+        try:
+            reports.append(validate_file(entity, path, validator, limit=args.limit))
+        except Exception as exc:  # noqa: BLE001 - advisory: one bad file must not stop the report
+            failed = EntityReport(entity=entity, path=path)
+            failed.skipped_reason = f"{type(exc).__name__}: {exc}"
+            reports.append(failed)
+
+    _emit(render_report(reports, args.target_schema, args.limit), args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dm_bip/map_data/validate_output.py
+++ b/src/dm_bip/map_data/validate_output.py
@@ -85,7 +85,9 @@ def load_records(path: Path) -> list[dict[str, Any]]:
         return [r for r in records if isinstance(r, dict)]
 
     if path.suffix == ".json":
-        doc = json.loads(path.read_text())
+        # A blank file is an empty document, not a parse error — same as yaml/jsonl.
+        text = path.read_text().strip()
+        doc = json.loads(text) if text else None
     else:
         docs = [d for d in yaml.safe_load_all(path.read_text()) if d is not None]
         if len(docs) > 1:

--- a/tests/unit/test_validate_output.py
+++ b/tests/unit/test_validate_output.py
@@ -68,6 +68,15 @@ def test_load_records_empty_file(tmp_path):
     assert load_records(path) == []
 
 
+@pytest.mark.parametrize("suffix", [".yaml", ".json", ".jsonl"])
+@pytest.mark.parametrize("content", ["", "   \n"])
+def test_load_records_empty_file_consistent_across_formats(tmp_path, suffix, content):
+    """An empty output file reads as 'no records' in every format, never a parse error."""
+    path = tmp_path / f"out{suffix}"
+    path.write_text(content)
+    assert load_records(path) == []
+
+
 def test_load_records_jsonl(tmp_path):
     """JSONL input is read line by line, ignoring blank lines."""
     path = tmp_path / "out.jsonl"

--- a/tests/unit/test_validate_output.py
+++ b/tests/unit/test_validate_output.py
@@ -1,0 +1,243 @@
+"""Unit tests for the mapped-output validation helper."""
+
+import json
+
+import pytest
+
+from dm_bip.map_data.validate_output import (
+    EntityReport,
+    Issue,
+    entity_output_path,
+    load_records,
+    main,
+    normalize_slot_path,
+    read_entity_list,
+    render_report,
+)
+
+SCHEMA = """
+id: https://example.org/target
+name: target
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Participant:
+    attributes:
+      id:
+        identifier: true
+      age:
+        range: integer
+"""
+
+
+def test_load_records_unwraps_container_key(tmp_path):
+    """linkml-map wraps records in a pluralized container key that is stripped."""
+    path = tmp_path / "out.yaml"
+    path.write_text("participants:\n- id: '1'\n- id: '2'\n")
+    assert load_records(path) == [{"id": "1"}, {"id": "2"}]
+
+
+def test_load_records_multi_document_stream(tmp_path):
+    """Current linkml-map emits one YAML document per record, separated by '---'."""
+    path = tmp_path / "out.yaml"
+    path.write_text("id: '1'\nage: 3\n---\nid: '2'\nage: 4\n")
+    assert load_records(path) == [{"id": "1", "age": 3}, {"id": "2", "age": 4}]
+
+
+def test_load_records_accepts_bare_list(tmp_path):
+    """A top-level list is treated as the record collection."""
+    path = tmp_path / "out.yaml"
+    path.write_text("- id: '1'\n- id: '2'\n")
+    assert load_records(path) == [{"id": "1"}, {"id": "2"}]
+
+
+def test_load_records_treats_multi_key_doc_as_single_record(tmp_path):
+    """A dict with several keys is a record, not a container."""
+    path = tmp_path / "out.yaml"
+    path.write_text("id: '1'\nage: 3\n")
+    assert load_records(path) == [{"id": "1", "age": 3}]
+
+
+def test_load_records_empty_file(tmp_path):
+    """An empty document yields no records rather than raising."""
+    path = tmp_path / "out.yaml"
+    path.write_text("")
+    assert load_records(path) == []
+
+
+def test_load_records_jsonl(tmp_path):
+    """JSONL input is read line by line, ignoring blank lines."""
+    path = tmp_path / "out.jsonl"
+    path.write_text('{"id": "1"}\n\n{"id": "2"}\n')
+    assert load_records(path) == [{"id": "1"}, {"id": "2"}]
+
+
+def test_load_records_json_container(tmp_path):
+    """JSON input is unwrapped the same way as YAML."""
+    path = tmp_path / "out.json"
+    path.write_text(json.dumps({"participants": [{"id": "1"}]}))
+    assert load_records(path) == [{"id": "1"}]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("$.observations[0].value", "$.observations[*].value"),
+        ("$.observations[12].a[3].b", "$.observations[*].a[*].b"),
+        ("$.id", "$.id"),
+    ],
+)
+def test_normalize_slot_path_collapses_indices(raw, expected):
+    """Array indices collapse so one systematic problem is one finding."""
+    assert normalize_slot_path(raw) == expected
+
+
+def test_entity_output_path_omits_empty_parts(tmp_path):
+    """Path building mirrors the Makefile's _map_base, skipping empty prefix/postfix."""
+    assert entity_output_path(tmp_path, "Participant") == tmp_path / "Participant.yaml"
+    assert entity_output_path(tmp_path, "Participant", "TOY", "-data") == tmp_path / "TOY-Participant--data.yaml"
+    assert entity_output_path(tmp_path, "P", fmt="jsonl") == tmp_path / "P.jsonl"
+
+
+def test_read_entity_list_missing_file(tmp_path):
+    """A missing entity list yields no entities rather than raising."""
+    assert read_entity_list(tmp_path / "nope") == []
+
+
+def test_read_entity_list_skips_blank_lines(tmp_path):
+    """Blank lines in the entity list are ignored."""
+    path = tmp_path / "entities"
+    path.write_text("Participant\n\n  Demography  \n")
+    assert read_entity_list(path) == ["Participant", "Demography"]
+
+
+def test_render_report_flags_invalid_records(tmp_path):
+    """The report summarizes counts and lists aggregated findings."""
+    report = EntityReport(entity="Participant", path=tmp_path / "p.yaml", total_records=2, checked_records=2)
+    report.invalid_records = 2
+    report.issues[("$.id", "type", "string")] = Issue(
+        slot_path="$.id", constraint="type", expected="string", count=2, examples=["1001 is not of type 'string'"]
+    )
+    body = render_report([report], tmp_path / "schema.yaml", 0)
+    assert "2 invalid (100.0%)" in body
+    assert "$.id" in body
+    assert "2x" in body
+    assert "advisory" in body
+
+
+def test_render_report_clean_run(tmp_path):
+    """A clean run says so explicitly."""
+    report = EntityReport(entity="Participant", path=tmp_path / "p.yaml", total_records=1, checked_records=1)
+    body = render_report([report], tmp_path / "schema.yaml", 0)
+    assert "No conformance issues found." in body
+    assert "[ok]" in body
+
+
+def test_empty_output_is_not_reported_as_clean(tmp_path):
+    """Zero records means the map step emitted nothing — never a pass."""
+    report = EntityReport(entity="Participant", path=tmp_path / "p.yaml")
+    assert not report.is_clean
+
+
+def test_main_flags_empty_entity_file(tmp_path):
+    """An empty mapped file is surfaced as a problem, not silently reported ok."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": "1"}])
+    (mapped / "Participant.yaml").write_text("")
+    code, report = _run(tmp_path, schema, mapped, entity_list)
+    assert code == 0
+    body = report.read_text()
+    assert "no records in output" in body
+    assert "[ok]" not in body
+
+
+def _write_inputs(tmp_path, records):
+    schema = tmp_path / "schema.yaml"
+    schema.write_text(SCHEMA)
+    mapped = tmp_path / "mapped"
+    mapped.mkdir()
+    (mapped / "Participant.yaml").write_text(json.dumps({"participants": records}))
+    entity_list = tmp_path / "entities"
+    entity_list.write_text("Participant\n")
+    return schema, mapped, entity_list
+
+
+def _run(tmp_path, schema, mapped, entity_list, extra=None):
+    report = tmp_path / "report.txt"
+    argv = [
+        "--target-schema",
+        str(schema),
+        "--mapped-dir",
+        str(mapped),
+        "--entity-list",
+        str(entity_list),
+        "--report",
+        str(report),
+        *(extra or []),
+    ]
+    return main(argv), report
+
+
+def test_main_reports_nonconforming_output(tmp_path):
+    """An integer in a string slot is reported, and the run still exits 0."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": 1001, "age": 3}])
+    code, report = _run(tmp_path, schema, mapped, entity_list)
+    assert code == 0
+    body = report.read_text()
+    assert "1 invalid" in body
+    assert "$.id" in body
+
+
+def test_main_exits_zero_on_conforming_output(tmp_path):
+    """Conforming output produces a clean report and exit 0."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": "1001", "age": 3}])
+    code, report = _run(tmp_path, schema, mapped, entity_list)
+    assert code == 0
+    assert "No conformance issues found." in report.read_text()
+
+
+def test_main_limit_caps_records_checked(tmp_path):
+    """--limit bounds how many records are validated per entity."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": n} for n in range(10)])
+    code, report = _run(tmp_path, schema, mapped, entity_list, ["--limit", "3"])
+    assert code == 0
+    body = report.read_text()
+    assert "3 checked" in body
+    assert "Record limit:  3" in body
+
+
+def test_main_writes_report_when_schema_missing(tmp_path):
+    """A missing target schema is recorded in the report, not a crash."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": "1"}])
+    code, report = _run(tmp_path, tmp_path / "absent.yaml", mapped, entity_list)
+    assert code == 0
+    assert "Skipped" in report.read_text()
+
+
+def test_main_writes_report_when_no_entities(tmp_path):
+    """An empty entity list still produces a report so Make sees the target built."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": "1"}])
+    entity_list.write_text("")
+    code, report = _run(tmp_path, schema, mapped, entity_list)
+    assert code == 0
+    assert "Skipped" in report.read_text()
+
+
+def test_main_skips_unsupported_format(tmp_path):
+    """TSV output is skipped with a reason: flattening makes validation unreliable."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": "1"}])
+    (mapped / "Participant.tsv").write_text("id\n1\n")
+    code, report = _run(tmp_path, schema, mapped, entity_list, ["--format", "tsv"])
+    assert code == 0
+    assert "unsupported format" in report.read_text()
+
+
+def test_main_reports_missing_entity_file(tmp_path):
+    """A listed entity with no output file is skipped with a reason, not a crash."""
+    schema, mapped, entity_list = _write_inputs(tmp_path, [{"id": "1"}])
+    entity_list.write_text("Participant\nAbsent\n")
+    code, report = _run(tmp_path, schema, mapped, entity_list)
+    assert code == 0
+    assert "file not found" in report.read_text()


### PR DESCRIPTION
Adds a `validate-output` pipeline stage that validates mapped output against `DM_MAP_TARGET_SCHEMA` and writes a report to `validation-logs/<SCHEMA>-output-validation.txt`.

**Advisory only** — the report never fails the pipeline. Enforcement is a separate decision once the real failure profile on BDCHM is known.

The map step passes `--target-schema` to linkml-map, but that only shapes the transformation; nothing asserted the emitted records conform to it. On toy data, every record fails: linkml-map emits source-native `int`/`float` values into slots whose range resolves to `string`, and does not coerce to the target schema. 1,650 record failures collapse to 6 issue classes, so findings are aggregated by entity / slot path / constraint rather than dumped per record.

Two things the report caught that are worth noting:

- `TOY-Demography--data.yaml` is empty — its mapping errored on a missing `sex_derived` source slot, yet the map step exited 0 and printed `✓ Data mapping complete`. Zero records is reported as a problem, never a pass.
- linkml-map's YAML output shape has changed across versions (multi-document stream vs. pluralized container key); both are handled.

`pipeline` now ends at the report when a target schema is configured, and falls back to the mapping sentinel when one isn't, preserving the single-endpoint invariant. `DM_VALIDATE_OUTPUT_LIMIT` caps records checked per entity for large datasets.

## Test plan

- [x] `make test` — 322 passed (24 new)
- [x] `make lint` clean on new files (notebook issues pre-existing)
- [x] `make validate-output` run end-to-end against toy data