### PR TITLE
Document what each Seven Bridges app runs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -159,15 +159,25 @@ production means creating a prod app from that same definition with its Docker
 Repository pointed at `dm-bip-prod/dm-bip-env:prod`. No code change is required;
 `bdc-cohort-workflow.sh` ships in every image.
 
-### Strict mapping is a property of the image, not the app
+### Strict mapping follows the image build, unless an app overrides it
 
-`DM_MAP_STRICT` is not an app input. It follows the `BDC_PULL_LATEST` build arg:
-dev images are built `true`, which makes `bdc-workflow.sh` pass
-`DM_MAP_STRICT=false` so a whole run's errors surface in one pass. Test and prod
-images are built `false`, leaving `DM_MAP_STRICT` at its `true` default --
-mapping fails on the first error. Cohort mode inherits this unchanged;
-`bdc-cohort-workflow.sh` never sets `DM_MAP_STRICT`, it just runs
+`DM_MAP_STRICT` is not an app input. Its default comes from the
+`BDC_PULL_LATEST` build arg: dev images are built `true`, which makes
+`bdc-workflow.sh` pass `DM_MAP_STRICT=false` so a whole run's errors surface in
+one pass. Test and prod images are built `false`, leaving `DM_MAP_STRICT` at its
+`true` default -- mapping fails on the first error. Cohort mode inherits this
+unchanged; `bdc-cohort-workflow.sh` never sets `DM_MAP_STRICT`, it just runs
 `bdc-workflow.sh` once per consent group.
+
+`BDC_PULL_LATEST` is a Dockerfile `ENV`, so it is a **default and not a fixed
+property of the image** -- an app can override it in its environment, and
+`docs/cohort-workflow.md` instructs operators to do exactly that when they need
+`--trans-spec` on a non-dev image. Overriding it to `true` also flips mapping to
+non-strict as a side effect, which is easy to miss.
+
+No app currently sets it: none of `cc-dm-bip-test`,
+`dmc-harmonization-multiconsent-app`, or `bdc-dm-bip-prod` declares an
+`EnvVarRequirement`, so today every app runs on its image's build-time value.
 
 Cohort mode has its own strictness controls -- `--strict-consent-groups` and
 `--strict-hv-dataqc`, both defaulting true -- which govern consent-group and QC

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -132,6 +132,52 @@ images.sb.biodatacatalyst.nhlbi.nih.gov/<username>/dm-bip-prod/dm-bip-env
 That is the current wiring, not a constraint -- any app can be pointed at any
 tier by editing its Docker Repository field.
 
+### What each app runs
+
+App definitions live only on the Seven Bridges platform; they are not in this
+repository and not under version control. This table is the record. When an app
+is created, repointed, or has its inputs changed, update it here in the same
+change -- otherwise the only way to answer "what does prod actually run?" is to
+probe the API, which is how a broken prod app went unnoticed for six weeks.
+
+| App | Entry point | Inputs |
+|-----|-------------|--------|
+| `cc-dm-bip-test` | `bdc-workflow.sh` | `Schema`, `RawSource`, `TransSpec`, `Profile` |
+| `dmc-harmonization-multiconsent-app` | `bdc-cohort-workflow.sh` | `Schema`, `ConsentGroups`, `DbgapCache`, `AllowFail`, `StrictConsentGroups`, `StrictHvDataqc`, `HvDataqcBranch`, `TransSpec`, `Jobs`, `ConsentParallelism` |
+| `bdc-dm-bip-prod` | `bdc-workflow.sh` | `Schema`, `RawSource` |
+
+An app must declare every input the CLI may send it. `dm-bip seven-bridges
+submit --profile` posts `Profile`, and `--trans-spec` posts `TransSpec`; an app
+without those inputs cannot accept them. `bdc-dm-bip-prod` declares neither,
+so prod currently runs single-consent harmonization with no trans-spec override
+and no diagnostics.
+
+**There is no cohort-mode app on the prod tier.** Cohort mode -- every consent
+group in one task plus the `hv_dataqc` source-vs-harmonized fan-in -- exists
+only as `dmc-harmonization-multiconsent-app` on the test tier. Putting it in
+production means creating a prod app from that same definition with its Docker
+Repository pointed at `dm-bip-prod/dm-bip-env:prod`. No code change is required;
+`bdc-cohort-workflow.sh` ships in every image.
+
+### Strict mode and profiling are properties of the image, not the app
+
+Neither is an app input, and neither differs between single-consent and cohort
+mode:
+
+- **Strict mapping** comes from the `BDC_PULL_LATEST` build arg. Dev images are
+  built `true`, which makes `bdc-workflow.sh` pass `DM_MAP_STRICT=false` so a
+  whole run's errors surface in one pass. Test and prod images are built
+  `false`, leaving `DM_MAP_STRICT` at its `true` default -- mapping fails on the
+  first error. Cohort mode inherits this: `bdc-cohort-workflow.sh` never sets
+  `DM_MAP_STRICT`, it just runs `bdc-workflow.sh` per consent group.
+- **Profiling** is opt-in per task via the `Profile` input, and only apps that
+  declare it can enable it. Diagnostics belong on dev, which can reach every
+  study prod can; there is no reason to profile in production.
+
+Cohort mode has its own strictness controls -- `--strict-consent-groups` and
+`--strict-hv-dataqc`, both defaulting true -- which govern consent-group and QC
+failure handling. Those are independent of map strictness.
+
 ### Tags each build publishes
 
 Every build publishes `:latest` plus an immutable `:sha-<12-char-commit>` tag. A

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -146,11 +146,11 @@ probe the API, which is how a broken prod app went unnoticed for six weeks.
 | `dmc-harmonization-multiconsent-app` | `bdc-cohort-workflow.sh` | `Schema`, `ConsentGroups`, `DbgapCache`, `AllowFail`, `StrictConsentGroups`, `StrictHvDataqc`, `HvDataqcBranch`, `TransSpec`, `Jobs`, `ConsentParallelism` |
 | `bdc-dm-bip-prod` | `bdc-workflow.sh` | `Schema`, `RawSource` |
 
-An app must declare every input the CLI may send it. `dm-bip seven-bridges
-submit --profile` posts `Profile`, and `--trans-spec` posts `TransSpec`; an app
-without those inputs cannot accept them. `bdc-dm-bip-prod` declares neither,
-so prod currently runs single-consent harmonization with no trans-spec override
-and no diagnostics.
+An app must declare every input the CLI may send it. In single-consent mode
+`submit --profile` posts `Profile` and `--trans-spec` posts `TransSpec`; an app
+without those inputs cannot accept them. `bdc-dm-bip-prod` declares neither, so
+prod currently runs single-consent harmonization with no trans-spec override and
+no diagnostics.
 
 **There is no cohort-mode app on the prod tier.** Cohort mode -- every consent
 group in one task plus the `hv_dataqc` source-vs-harmonized fan-in -- exists
@@ -159,24 +159,33 @@ production means creating a prod app from that same definition with its Docker
 Repository pointed at `dm-bip-prod/dm-bip-env:prod`. No code change is required;
 `bdc-cohort-workflow.sh` ships in every image.
 
-### Strict mode and profiling are properties of the image, not the app
+### Strict mapping is a property of the image, not the app
 
-Neither is an app input, and neither differs between single-consent and cohort
-mode:
-
-- **Strict mapping** comes from the `BDC_PULL_LATEST` build arg. Dev images are
-  built `true`, which makes `bdc-workflow.sh` pass `DM_MAP_STRICT=false` so a
-  whole run's errors surface in one pass. Test and prod images are built
-  `false`, leaving `DM_MAP_STRICT` at its `true` default -- mapping fails on the
-  first error. Cohort mode inherits this: `bdc-cohort-workflow.sh` never sets
-  `DM_MAP_STRICT`, it just runs `bdc-workflow.sh` per consent group.
-- **Profiling** is opt-in per task via the `Profile` input, and only apps that
-  declare it can enable it. Diagnostics belong on dev, which can reach every
-  study prod can; there is no reason to profile in production.
+`DM_MAP_STRICT` is not an app input. It follows the `BDC_PULL_LATEST` build arg:
+dev images are built `true`, which makes `bdc-workflow.sh` pass
+`DM_MAP_STRICT=false` so a whole run's errors surface in one pass. Test and prod
+images are built `false`, leaving `DM_MAP_STRICT` at its `true` default --
+mapping fails on the first error. Cohort mode inherits this unchanged;
+`bdc-cohort-workflow.sh` never sets `DM_MAP_STRICT`, it just runs
+`bdc-workflow.sh` once per consent group.
 
 Cohort mode has its own strictness controls -- `--strict-consent-groups` and
 `--strict-hv-dataqc`, both defaulting true -- which govern consent-group and QC
 failure handling. Those are independent of map strictness.
+
+### Profiling is single-consent only
+
+Unlike strict mapping, profiling *is* an app input: it is opt-in per task via
+`Profile`, so only an app that declares it can enable it, and only
+`cc-dm-bip-test` does.
+
+It is also single-consent only on the CLI side. `submit` accepts `--profile`,
+but the cohort branch does not forward it, so passing it alongside
+`--cohort-mode` has no effect. There is no cohort-mode app declaring `Profile`
+either, on any tier.
+
+Diagnostics belong on dev, which can reach every study prod can; there is no
+reason to profile in production.
 
 ### Tags each build publishes
 


### PR DESCRIPTION
App definitions live only on the Seven Bridges platform — not in this repo, not under version control. Until now the only way to answer "what does prod actually run?" was to probe the API, which is how `bdc-dm-bip-prod` sat pointed at an unpullable registry account from mid-July until this week without anyone noticing.

Records each app's entry point and declared inputs, and three things that fall out of writing it down:

- `bdc-dm-bip-prod` declares only `Schema` and `RawSource` — no `TransSpec`, no `Profile`. Prod cannot accept a trans-spec override or diagnostics, and `submit --profile` against it would post an input it does not declare.
- **There is no cohort-mode app on the prod tier.** Cohort mode plus the `hv_dataqc` fan-in exists only as `dmc-harmonization-multiconsent-app` on test. Putting it in prod is an app-creation step, not a code change — `bdc-cohort-workflow.sh` ships in every image.
- Strict mapping and profiling are properties of the **image build**, not the app or the execution mode. Prod images are built `BDC_PULL_LATEST=false`, so `DM_MAP_STRICT` stays at its `true` default, and cohort mode inherits that because `bdc-cohort-workflow.sh` just runs `bdc-workflow.sh` per consent group without overriding it.

This is a record, not a source of truth — the platform stays authoritative. It is the written expectation that makes the pre-submit contract check in #362 meaningful later.